### PR TITLE
Bug/65 bug commandexecuteasync does not forward

### DIFF
--- a/Hyperbee.Pipeline.sln.DotSettings
+++ b/Hyperbee.Pipeline.sln.DotSettings
@@ -1,2 +1,3 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/GrammarAndSpelling/GrammarChecking/Exceptions/=Setup_0020the/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Hyperbee/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/src/Hyperbee.Pipeline/Commands/CommandFunction.cs
+++ b/src/Hyperbee.Pipeline/Commands/CommandFunction.cs
@@ -22,7 +22,7 @@ public abstract class CommandFunction<TStart, TOutput> : ICommandFunction<TStart
 
     public virtual async Task<CommandResult<TOutput>> ExecuteAsync( TStart argument, CancellationToken cancellation = default )
     {
-        var context = ContextFactory.Create( Logger );
+        var context = ContextFactory.Create( Logger, cancellation );
 
         return new CommandResult<TOutput>
         {

--- a/src/Hyperbee.Pipeline/Commands/CommandProcedure.cs
+++ b/src/Hyperbee.Pipeline/Commands/CommandProcedure.cs
@@ -22,7 +22,7 @@ public abstract class CommandProcedure<TStart> : ICommandProcedure<TStart>
 
     public virtual async Task<CommandResult> ExecuteAsync( TStart argument, CancellationToken cancellation = default )
     {
-        var context = ContextFactory.Create( Logger );
+        var context = ContextFactory.Create( Logger, cancellation );
 
         await Pipeline.Value( context, argument ).ConfigureAwait( false );
 

--- a/src/Hyperbee.Pipeline/Context/IPipelineContextFactory.cs
+++ b/src/Hyperbee.Pipeline/Context/IPipelineContextFactory.cs
@@ -4,5 +4,5 @@ namespace Hyperbee.Pipeline.Context;
 
 public interface IPipelineContextFactory
 {
-    IPipelineContext Create( ILogger logger );
+    IPipelineContext Create( ILogger logger, CancellationToken cancellation = default );
 }

--- a/src/Hyperbee.Pipeline/Context/PipelineContextFactory.cs
+++ b/src/Hyperbee.Pipeline/Context/PipelineContextFactory.cs
@@ -15,9 +15,9 @@ public class PipelineContextFactory : IPipelineContextFactory
         _serviceProvider = serviceProvider;
     }
 
-    public IPipelineContext Create( ILogger logger )
+    public IPipelineContext Create( ILogger logger, CancellationToken cancellation = default )
     {
-        return new PipelineContext
+        return new PipelineContext( cancellation )
         {
             Logger = logger,
             ServiceProvider = _serviceProvider

--- a/test/Hyperbee.Pipeline.Tests/CommandFunctionTests.cs
+++ b/test/Hyperbee.Pipeline.Tests/CommandFunctionTests.cs
@@ -18,21 +18,21 @@ public class CommandFunctionTests
         var logger = Substitute.For<ILogger>();
         var mockContextFactory = Substitute.For<IPipelineContextFactory>();
         var mockContext = Substitute.For<IPipelineContext>();
-        
+
         using var cancellationTokenSource = new CancellationTokenSource();
         var cancellationToken = cancellationTokenSource.Token;
-        
+
         // Setup the factory to return our mock context
-        mockContextFactory.Create(logger, cancellationToken).Returns(mockContext);
-        
+        mockContextFactory.Create( logger, cancellationToken ).Returns( mockContext );
+
         // Create a test command function
-        var testCommand = new TestCommandFunction(mockContextFactory, logger);
-        
+        var testCommand = new TestCommandFunction( mockContextFactory, logger );
+
         // Act
-        await testCommand.ExecuteAsync(0, cancellationToken);
-        
+        await testCommand.ExecuteAsync( 0, cancellationToken );
+
         // Assert
-        mockContextFactory.Received(1).Create(logger, cancellationToken);
+        mockContextFactory.Received( 1 ).Create( logger, cancellationToken );
     }
 
     [TestMethod]
@@ -42,21 +42,21 @@ public class CommandFunctionTests
         var logger = Substitute.For<ILogger>();
         var mockContextFactory = Substitute.For<IPipelineContextFactory>();
         var mockContext = Substitute.For<IPipelineContext>();
-        
+
         using var cancellationTokenSource = new CancellationTokenSource();
         var cancellationToken = cancellationTokenSource.Token;
-        
+
         // Setup the factory to return our mock context
-        mockContextFactory.Create(logger, cancellationToken).Returns(mockContext);
-        
+        mockContextFactory.Create( logger, cancellationToken ).Returns( mockContext );
+
         // Create a test command function (parameterless version)
-        var testCommand = new TestCommandFunctionParameterless(mockContextFactory, logger);
-        
+        var testCommand = new TestCommandFunctionParameterless( mockContextFactory, logger );
+
         // Act
-        await testCommand.ExecuteAsync(cancellationToken);
-        
+        await testCommand.ExecuteAsync( cancellationToken );
+
         // Assert
-        mockContextFactory.Received(1).Create(logger, cancellationToken);
+        mockContextFactory.Received( 1 ).Create( logger, cancellationToken );
     }
 
     [TestMethod]
@@ -66,17 +66,17 @@ public class CommandFunctionTests
         var logger = Substitute.For<ILogger>();
         var mockContextFactory = Substitute.For<IPipelineContextFactory>();
         var mockContext = Substitute.For<IPipelineContext>();
-        
+
         // Setup the factory to return our mock context with default cancellation token
-        mockContextFactory.Create(logger, default(CancellationToken)).Returns(mockContext);
-        
-        var testCommand = new TestCommandFunction(mockContextFactory, logger);
-        
+        mockContextFactory.Create( logger, default( CancellationToken ) ).Returns( mockContext );
+
+        var testCommand = new TestCommandFunction( mockContextFactory, logger );
+
         // Act
-        await testCommand.ExecuteAsync(0);
-        
+        await testCommand.ExecuteAsync( 0 );
+
         // Assert
-        mockContextFactory.Received(1).Create(logger, default(CancellationToken));
+        mockContextFactory.Received( 1 ).Create( logger, default( CancellationToken ) );
     }
 
     [TestMethod]
@@ -84,25 +84,25 @@ public class CommandFunctionTests
     {
         // Arrange
         var logger = Substitute.For<ILogger>();
-        var contextFactory = PipelineContextFactory.CreateFactory(resetFactory: true);
-        
+        var contextFactory = PipelineContextFactory.CreateFactory( resetFactory: true );
+
         using var cancellationTokenSource = new CancellationTokenSource();
         var cancellationToken = cancellationTokenSource.Token;
-        
-        var testCommand = new TestCommandFunction(contextFactory, logger);
-        
+
+        var testCommand = new TestCommandFunction( contextFactory, logger );
+
         // Act
-        var result = await testCommand.ExecuteAsync(0, cancellationToken);
-        
+        var result = await testCommand.ExecuteAsync( 0, cancellationToken );
+
         // Assert
-        Assert.AreEqual(cancellationToken, result.Context.CancellationToken);
+        Assert.AreEqual( cancellationToken, result.Context.CancellationToken );
     }
 
     // Test implementation of CommandFunction<TStart, TOutput>
     private class TestCommandFunction : CommandFunction<int, int>
     {
-        public TestCommandFunction(IPipelineContextFactory pipelineContextFactory, ILogger logger) 
-            : base(pipelineContextFactory, logger)
+        public TestCommandFunction( IPipelineContextFactory pipelineContextFactory, ILogger logger )
+            : base( pipelineContextFactory, logger )
         {
         }
 
@@ -118,8 +118,8 @@ public class CommandFunctionTests
     // Test implementation of CommandFunction<TOutput> (parameterless version)
     private class TestCommandFunctionParameterless : CommandFunction<int>
     {
-        public TestCommandFunctionParameterless(IPipelineContextFactory pipelineContextFactory, ILogger logger) 
-            : base(pipelineContextFactory, logger)
+        public TestCommandFunctionParameterless( IPipelineContextFactory pipelineContextFactory, ILogger logger )
+            : base( pipelineContextFactory, logger )
         {
         }
 

--- a/test/Hyperbee.Pipeline.Tests/CommandFunctionTests.cs
+++ b/test/Hyperbee.Pipeline.Tests/CommandFunctionTests.cs
@@ -55,34 +55,34 @@ public class CommandFunctionTests
         mockContextFactory.Received( 1 ).Create( logger, default( CancellationToken ) );
     }
 
-        [TestMethod]
+    [TestMethod]
     public async Task CommandFunction_ExecuteAsync_Should_Link_And_Propagate_Cancellation()
     {
         // Arrange
         var logger = Substitute.For<ILogger>();
-        var contextFactory = PipelineContextFactory.CreateFactory(resetFactory: true);
+        var contextFactory = PipelineContextFactory.CreateFactory( resetFactory: true );
 
         using var cts = new CancellationTokenSource();
         var originalToken = cts.Token;
 
-        var testCommand = new TestCommandFunction(contextFactory, logger);
+        var testCommand = new TestCommandFunction( contextFactory, logger );
 
         // Act
-        var result = await testCommand.ExecuteAsync(0, originalToken);
+        var result = await testCommand.ExecuteAsync( 0, originalToken );
         var contextToken = result.Context.CancellationToken;
 
         // Assert
         // The context creates a linked token source, so the tokens should not be equal
-        Assert.AreNotEqual(originalToken, contextToken, "Context should use a linked CancellationTokenSource.");
+        Assert.AreNotEqual( originalToken, contextToken, "Context should use a linked CancellationTokenSource." );
 
-        Assert.IsFalse(originalToken.IsCancellationRequested, "Original token should not be canceled yet.");
-        Assert.IsFalse(contextToken.IsCancellationRequested, "Linked context token should not be canceled yet.");
+        Assert.IsFalse( originalToken.IsCancellationRequested, "Original token should not be canceled yet." );
+        Assert.IsFalse( contextToken.IsCancellationRequested, "Linked context token should not be canceled yet." );
 
         // Cancel the original and ensure propagation to the linked token
         await cts.CancelAsync();
 
-        Assert.IsTrue(originalToken.IsCancellationRequested, "Original token should be canceled.");
-        Assert.IsTrue(contextToken.IsCancellationRequested, "Linked context token should be canceled when original is canceled.");
+        Assert.IsTrue( originalToken.IsCancellationRequested, "Original token should be canceled." );
+        Assert.IsTrue( contextToken.IsCancellationRequested, "Linked context token should be canceled when original is canceled." );
     }
 
     [TestMethod]
@@ -90,27 +90,27 @@ public class CommandFunctionTests
     {
         // Arrange
         var logger = Substitute.For<ILogger>();
-        var contextFactory = PipelineContextFactory.CreateFactory(resetFactory: true);
+        var contextFactory = PipelineContextFactory.CreateFactory( resetFactory: true );
 
         using var cts = new CancellationTokenSource();
         var originalToken = cts.Token;
 
-        var testCommand = new TestCommandFunction(contextFactory, logger);
+        var testCommand = new TestCommandFunction( contextFactory, logger );
 
         // Act
-        var result = await testCommand.ExecuteAsync(0, originalToken);
+        var result = await testCommand.ExecuteAsync( 0, originalToken );
         var contextToken = result.Context.CancellationToken;
 
         // Assert preconditions
-        Assert.AreNotEqual(originalToken, contextToken);
-        Assert.IsFalse(originalToken.IsCancellationRequested);
-        Assert.IsFalse(contextToken.IsCancellationRequested);
+        Assert.AreNotEqual( originalToken, contextToken );
+        Assert.IsFalse( originalToken.IsCancellationRequested );
+        Assert.IsFalse( contextToken.IsCancellationRequested );
 
         // Cancel via context (one-way: does not flow back to original)
         result.Context.CancelAfter();
 
-        Assert.IsTrue(contextToken.IsCancellationRequested, "Context token should be canceled.");
-        Assert.IsFalse(originalToken.IsCancellationRequested, "Original token should not be canceled by context cancellation.");
+        Assert.IsTrue( contextToken.IsCancellationRequested, "Context token should be canceled." );
+        Assert.IsFalse( originalToken.IsCancellationRequested, "Original token should not be canceled by context cancellation." );
     }
 
     // Test implementation of CommandFunction<TStart, TOutput>

--- a/test/Hyperbee.Pipeline.Tests/CommandFunctionTests.cs
+++ b/test/Hyperbee.Pipeline.Tests/CommandFunctionTests.cs
@@ -1,0 +1,134 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+using Hyperbee.Pipeline.Commands;
+using Hyperbee.Pipeline.Context;
+using Microsoft.Extensions.Logging;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NSubstitute;
+
+namespace Hyperbee.Pipeline.Tests;
+
+[TestClass]
+public class CommandFunctionTests
+{
+    [TestMethod]
+    public async Task CommandFunction_ExecuteAsync_Should_Pass_CancellationToken_To_Context()
+    {
+        // Arrange
+        var logger = Substitute.For<ILogger>();
+        var mockContextFactory = Substitute.For<IPipelineContextFactory>();
+        var mockContext = Substitute.For<IPipelineContext>();
+        
+        using var cancellationTokenSource = new CancellationTokenSource();
+        var cancellationToken = cancellationTokenSource.Token;
+        
+        // Setup the factory to return our mock context
+        mockContextFactory.Create(logger, cancellationToken).Returns(mockContext);
+        
+        // Create a test command function
+        var testCommand = new TestCommandFunction(mockContextFactory, logger);
+        
+        // Act
+        await testCommand.ExecuteAsync(0, cancellationToken);
+        
+        // Assert
+        mockContextFactory.Received(1).Create(logger, cancellationToken);
+    }
+
+    [TestMethod]
+    public async Task CommandFunction_ExecuteAsync_WithoutArgument_Should_Pass_CancellationToken_To_Context()
+    {
+        // Arrange
+        var logger = Substitute.For<ILogger>();
+        var mockContextFactory = Substitute.For<IPipelineContextFactory>();
+        var mockContext = Substitute.For<IPipelineContext>();
+        
+        using var cancellationTokenSource = new CancellationTokenSource();
+        var cancellationToken = cancellationTokenSource.Token;
+        
+        // Setup the factory to return our mock context
+        mockContextFactory.Create(logger, cancellationToken).Returns(mockContext);
+        
+        // Create a test command function (parameterless version)
+        var testCommand = new TestCommandFunctionParameterless(mockContextFactory, logger);
+        
+        // Act
+        await testCommand.ExecuteAsync(cancellationToken);
+        
+        // Assert
+        mockContextFactory.Received(1).Create(logger, cancellationToken);
+    }
+
+    [TestMethod]
+    public async Task CommandFunction_ExecuteAsync_Should_Pass_Default_CancellationToken_When_None_Provided()
+    {
+        // Arrange
+        var logger = Substitute.For<ILogger>();
+        var mockContextFactory = Substitute.For<IPipelineContextFactory>();
+        var mockContext = Substitute.For<IPipelineContext>();
+        
+        // Setup the factory to return our mock context with default cancellation token
+        mockContextFactory.Create(logger, default(CancellationToken)).Returns(mockContext);
+        
+        var testCommand = new TestCommandFunction(mockContextFactory, logger);
+        
+        // Act
+        await testCommand.ExecuteAsync(0);
+        
+        // Assert
+        mockContextFactory.Received(1).Create(logger, default(CancellationToken));
+    }
+
+    [TestMethod]
+    public async Task CommandFunction_ExecuteAsync_Should_Return_Context_With_Correct_CancellationToken()
+    {
+        // Arrange
+        var logger = Substitute.For<ILogger>();
+        var contextFactory = PipelineContextFactory.CreateFactory(resetFactory: true);
+        
+        using var cancellationTokenSource = new CancellationTokenSource();
+        var cancellationToken = cancellationTokenSource.Token;
+        
+        var testCommand = new TestCommandFunction(contextFactory, logger);
+        
+        // Act
+        var result = await testCommand.ExecuteAsync(0, cancellationToken);
+        
+        // Assert
+        Assert.AreEqual(cancellationToken, result.Context.CancellationToken);
+    }
+
+    // Test implementation of CommandFunction<TStart, TOutput>
+    private class TestCommandFunction : CommandFunction<int, int>
+    {
+        public TestCommandFunction(IPipelineContextFactory pipelineContextFactory, ILogger logger) 
+            : base(pipelineContextFactory, logger)
+        {
+        }
+
+        protected override FunctionAsync<int, int> CreatePipeline()
+        {
+            return PipelineFactory
+                .Start<int>()
+                .Pipe( ( context, input ) => 42 )
+                .Build();
+        }
+    }
+
+    // Test implementation of CommandFunction<TOutput> (parameterless version)
+    private class TestCommandFunctionParameterless : CommandFunction<int>
+    {
+        public TestCommandFunctionParameterless(IPipelineContextFactory pipelineContextFactory, ILogger logger) 
+            : base(pipelineContextFactory, logger)
+        {
+        }
+
+        protected override FunctionAsync<Arg.Empty, int> CreatePipeline()
+        {
+            return PipelineFactory
+                .Start<Arg.Empty>()
+                .Pipe( ( context, input ) => 42 )
+                .Build();
+        }
+    }
+}

--- a/test/Hyperbee.Pipeline.Tests/Hyperbee.Pipeline.Tests.csproj
+++ b/test/Hyperbee.Pipeline.Tests/Hyperbee.Pipeline.Tests.csproj
@@ -7,6 +7,7 @@
     <PackageReference Include="MSTest.TestAdapter" Version="3.9.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="MSTest.TestFramework" Version="3.9.3" />
+    <PackageReference Include="NSubstitute" Version="5.3.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Hyperbee.Pipeline\Hyperbee.Pipeline.csproj" />


### PR DESCRIPTION
## Description

Pipelines were not correctly passing cancellation tokens to the pipeline's context

 - `Fixes #65 

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation

## Checklist

- [x] I have run the existing tests and they pass
- [ ] I have run the existing benchmarks and verified that performance has not decreased
- [ ] I have added new tests that prove my change is effective or that my feature works
- [ ] I have added the necessary documentation (if applicable)
