### PR TITLE
Improve validation registration pattern

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -23,24 +23,24 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-    <PackageIcon>assets/icon.png</PackageIcon>
+    <PackageIcon>icon.png</PackageIcon>
     <PackageReleaseNotes>https://github.com/Stillpoint-Software/Hyperbee.Pipeline/releases/latest</PackageReleaseNotes>
     <RepositoryUrl>https://github.com/Stillpoint-Software/Hyperbee.Pipeline</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageProjectUrl>https://github.com/Stillpoint-Software/Hyperbee.Pipeline</PackageProjectUrl>
   </PropertyGroup>
 
-  <!-- Pull README & LICENSE into the package root -->
+  <!-- Pull icon, README & LICENSE into the package root -->
   <ItemGroup Condition="'$(IsPackable)' == 'true'">
-    <None Include="$(MSBuildThisFileDirectory)README.md"
+    <None Include="$(MSBuildThisFileDirectory)assets/icon.png"
           Pack="true"
-          PackagePath="\"
-    Link="README.md" />
+          Visible="false"
+          PackagePath="/" />
 
     <None Include="$(MSBuildThisFileDirectory)LICENSE"
           Pack="true"
           PackagePath="\"
-    Link="LICENSE" />
+          Link="LICENSE" />
   </ItemGroup>
   <!-- Global project properties - .NET 10 LTS First Strategy -->
   <PropertyGroup>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -32,6 +32,10 @@
 
   <!-- Pull icon, README & LICENSE into the package root -->
   <ItemGroup Condition="'$(IsPackable)' == 'true'">
+    <None Include="$(MSBuildThisFileDirectory)README.md"
+          Pack="true"
+          PackagePath="\"
+    Link="README.md" />
     <None Include="$(MSBuildThisFileDirectory)assets/icon.png"
           Pack="true"
           Visible="false"

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -32,10 +32,6 @@
 
   <!-- Pull icon, README & LICENSE into the package root -->
   <ItemGroup Condition="'$(IsPackable)' == 'true'">
-    <None Include="$(MSBuildThisFileDirectory)README.md"
-          Pack="true"
-          PackagePath="\"
-    Link="README.md" />
     <None Include="$(MSBuildThisFileDirectory)assets/icon.png"
           Pack="true"
           Visible="false"

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -48,8 +48,9 @@ public class OrderValidator : AbstractValidator<Order>
 }
 
 // 3. Register validators in DI
-services.AddFluentValidation(options =>
-    options.ScanAssembly(typeof(OrderValidator).Assembly));
+services.AddPipelineValidation(config =>
+    config.UseFluentValidation(options =>
+        options.ScanAssembly(typeof(OrderValidator).Assembly)));
 
 // 4. Use ValidateAsync in your pipeline
 var command = PipelineFactory
@@ -374,8 +375,9 @@ public class OrderValidator : AbstractValidator<Order> { }
 public class PaymentValidator : IValidator<Payment> { }
 
 // In Startup.cs
-services.AddFluentValidation(options =>
-    options.ScanAssembly(Assembly.GetExecutingAssembly()));
+services.AddPipelineValidation(config =>
+    config.UseFluentValidation(options =>
+        options.ScanAssembly(Assembly.GetExecutingAssembly())));
 
 // FluentValidatorProvider will only return validators for types with FluentValidation validators
 // You can chain or create a composite provider for mixed scenarios
@@ -449,7 +451,7 @@ Adapter that integrates FluentValidation:
 
 - `FluentValidatorProvider` - Resolves FluentValidation validators from DI
 - Adapter classes that bridge FluentValidation types to pipeline abstractions
-- `AddFluentValidation()` extension method for DI registration
+- `UseFluentValidation()` extension method for DI registration via `AddPipelineValidation`
 
 **This is the recommended package for most users.**
 

--- a/src/Hyperbee.Pipeline.AspNetCore/Hyperbee.Pipeline.AspNetCore.csproj
+++ b/src/Hyperbee.Pipeline.AspNetCore/Hyperbee.Pipeline.AspNetCore.csproj
@@ -9,22 +9,10 @@
     <PackageId>Hyperbee.Pipeline.AspNetCore</PackageId>
     <Description>ASP.NET Core integration for Hyperbee.Pipeline with command result mapping and validation</Description>
     <PackageTags>pipeline;aspnetcore;minimal-api;validation</PackageTags>
-    <PackageIcon>icon.png</PackageIcon>
-    <PackageProjectUrl>https://github.com/Stillpoint-Software/Hyperbee.Pipeline/</PackageProjectUrl>
-    <PackageReleaseNotes>https://github.com/Stillpoint-Software/hyperbee.pipeline/releases/latest</PackageReleaseNotes>
-    <PackageLicenseFile>LICENSE</PackageLicenseFile>
-    <PackageReadmeFile>README.md</PackageReadmeFile>
-    <RepositoryUrl>https://github.com/Stillpoint-Software/Hyperbee.Pipeline</RepositoryUrl>
-    <RepositoryType>git</RepositoryType>
   </PropertyGroup>
 
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
-    <None Include="..\..\assets\icon.png" Pack="true" Visible="false" PackagePath="/" />
-    <None Include="..\..\LICENSE">
-      <Pack>True</Pack>
-      <PackagePath>\</PackagePath>
-    </None>
     <None Include="README.md">
       <Pack>True</Pack>
       <PackagePath>\</PackagePath>

--- a/src/Hyperbee.Pipeline.Auth/Hyperbee.Pipeline.Auth.csproj
+++ b/src/Hyperbee.Pipeline.Auth/Hyperbee.Pipeline.Auth.csproj
@@ -1,30 +1,17 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <IsPackable>true</IsPackable>
     <Authors>Stillpoint Software, Inc.</Authors>
-    <PackageReadmeFile>README.md</PackageReadmeFile>
-    <PackageTags>pipeline;auth</PackageTags>
-    <PackageIcon>icon.png</PackageIcon>
-    <PackageProjectUrl>https://github.com/Stillpoint-Software/Hyperbee.Pipeline/</PackageProjectUrl>
-    <PackageReleaseNotes>https://github.com/Stillpoint-Software/hyperbee.pipeline/releases/latest</PackageReleaseNotes>
-    <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <Copyright>Stillpoint Software, Inc.</Copyright>
+    <PackageTags>pipeline;auth</PackageTags>
     <Title>Hyperbee Pipline Auth</Title>
     <PackageId>Hyperbee.Pipeline.Auth</PackageId>
     <Description>Auth for Hyperbee.Pipelines async pipelines</Description>
-    <RepositoryUrl>https://github.com/Stillpoint-Software/Hyperbee.Pipeline</RepositoryUrl>
-    <RepositoryType>git</RepositoryType>
-    <PackageReleaseNotes>https://github.com/Stillpoint-Software/hyperbee.pipeline/releases/latest</PackageReleaseNotes>
   </PropertyGroup>
 
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
-    <None Include="..\..\assets\icon.png" Pack="true" Visible="false" PackagePath="/" />
-    <None Include="..\..\LICENSE">
-      <Pack>True</Pack>
-      <PackagePath>\</PackagePath>
-    </None>
     <None Include="README.md">
       <Pack>True</Pack>
       <PackagePath>\</PackagePath>
@@ -33,4 +20,5 @@
     <ProjectReference Include="..\Hyperbee.Pipeline\Hyperbee.Pipeline.csproj" />
     <PackageReference Update="Microsoft.SourceLink.GitHub" />
   </ItemGroup>
+
 </Project>

--- a/src/Hyperbee.Pipeline.TestHelpers/Hyperbee.Pipeline.TestHelpers.csproj
+++ b/src/Hyperbee.Pipeline.TestHelpers/Hyperbee.Pipeline.TestHelpers.csproj
@@ -9,21 +9,9 @@
     <PackageId>Hyperbee.Pipeline.TestHelpers</PackageId>
     <Description>Test helpers and fixtures for Hyperbee.Pipeline commands and validation</Description>
     <PackageTags>pipeline;testing;test-helpers</PackageTags>
-    <PackageIcon>icon.png</PackageIcon>
-    <PackageProjectUrl>https://github.com/Stillpoint-Software/Hyperbee.Pipeline/</PackageProjectUrl>
-    <PackageReleaseNotes>https://github.com/Stillpoint-Software/hyperbee.pipeline/releases/latest</PackageReleaseNotes>
-    <PackageLicenseFile>LICENSE</PackageLicenseFile>
-    <PackageReadmeFile>README.md</PackageReadmeFile>
-    <RepositoryUrl>https://github.com/Stillpoint-Software/Hyperbee.Pipeline</RepositoryUrl>
-    <RepositoryType>git</RepositoryType>
   </PropertyGroup>
 
   <ItemGroup>
-    <None Include="..\..\assets\icon.png" Pack="true" Visible="false" PackagePath="/" />
-    <None Include="..\..\LICENSE">
-      <Pack>True</Pack>
-      <PackagePath>\</PackagePath>
-    </None>
     <None Include="README.md">
       <Pack>True</Pack>
       <PackagePath>\</PackagePath>

--- a/src/Hyperbee.Pipeline.Validation.FluentValidation/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Hyperbee.Pipeline.Validation.FluentValidation/Extensions/ServiceCollectionExtensions.cs
@@ -1,4 +1,4 @@
-using System.Reflection;
+﻿using System.Reflection;
 using FluentValidation;
 using Hyperbee.Pipeline.Validation;
 using Microsoft.Extensions.DependencyInjection;

--- a/src/Hyperbee.Pipeline.Validation.FluentValidation/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Hyperbee.Pipeline.Validation.FluentValidation/Extensions/ServiceCollectionExtensions.cs
@@ -1,4 +1,4 @@
-﻿using System.Reflection;
+using System.Reflection;
 using FluentValidation;
 using Hyperbee.Pipeline.Validation;
 using Microsoft.Extensions.DependencyInjection;
@@ -6,38 +6,43 @@ using Microsoft.Extensions.DependencyInjection;
 namespace Hyperbee.Pipeline.Validation.FluentValidation;
 
 /// <summary>
-/// Provides extension methods for registering FluentValidation with the dependency injection container.
+/// Provides extension methods for registering FluentValidation as the pipeline validation provider.
 /// </summary>
 public static class ServiceCollectionExtensions
 {
     /// <summary>
-    /// Registers FluentValidation support for Hyperbee.Pipeline validation.
+    /// Configures FluentValidation as the pipeline validation provider.
     /// </summary>
-    /// <param name="services">The service collection.</param>
+    /// <param name="config">The pipeline validation configuration.</param>
     /// <param name="configure">Optional configuration action for specifying assemblies to scan for validators.</param>
-    /// <returns>The service collection for method chaining.</returns>
+    /// <returns>The pipeline validation configuration for method chaining.</returns>
     /// <example>
     /// <code>
-    /// services.AddFluentValidation(options =>
-    ///     options.ScanAssembly(typeof(OrderValidator).Assembly));
+    /// // Recommended: scan for validators automatically
+    /// services.AddPipelineValidation(config =>
+    ///     config.UseFluentValidation(options =>
+    ///         options.ScanAssembly(typeof(OrderValidator).Assembly)));
+    ///
+    /// // If you already register FluentValidation validators separately, omit the scanner:
+    /// services.AddValidatorsFromAssemblyContaining&lt;OrderValidator&gt;();
+    /// services.AddPipelineValidation(config => config.UseFluentValidation());
     /// </code>
     /// </example>
-    public static IServiceCollection AddFluentValidation(
-        this IServiceCollection services,
+    public static IPipelineValidationConfiguration UseFluentValidation(
+        this IPipelineValidationConfiguration config,
         Action<FluentValidationOptions>? configure = null )
     {
-        services.AddSingleton<IValidatorProvider, FluentValidatorProvider>();
+        config.Services.AddSingleton<IValidatorProvider, FluentValidatorProvider>();
 
-        // Auto-register FluentValidation validators from assembly scanning
         var options = new FluentValidationOptions();
         configure?.Invoke( options );
 
         foreach ( var assembly in options.AssembliesToScan )
         {
-            services.AddValidatorsFromAssembly( assembly );
+            config.Services.AddValidatorsFromAssembly( assembly );
         }
 
-        return services;
+        return config;
     }
 }
 
@@ -49,7 +54,7 @@ public class FluentValidationOptions
     /// <summary>
     /// Gets the list of assemblies to scan for FluentValidation validators.
     /// </summary>
-    public List<Assembly> AssembliesToScan { get; } = new();
+    public List<Assembly> AssembliesToScan { get; } = [];
 
     /// <summary>
     /// Adds an assembly to scan for FluentValidation validators.

--- a/src/Hyperbee.Pipeline.Validation.FluentValidation/Hyperbee.Pipeline.Validation.FluentValidation.csproj
+++ b/src/Hyperbee.Pipeline.Validation.FluentValidation/Hyperbee.Pipeline.Validation.FluentValidation.csproj
@@ -10,21 +10,9 @@
     <AssemblyName>Hyperbee.Pipeline.Validation.FluentValidation</AssemblyName>
     <Description>FluentValidation integration for Hyperbee.Pipeline async pipelines</Description>
     <PackageTags>pipeline;validation;fluent-validation</PackageTags>
-    <PackageIcon>icon.png</PackageIcon>
-    <PackageProjectUrl>https://github.com/Stillpoint-Software/Hyperbee.Pipeline/</PackageProjectUrl>
-    <PackageReleaseNotes>https://github.com/Stillpoint-Software/hyperbee.pipeline/releases/latest</PackageReleaseNotes>
-    <PackageLicenseFile>LICENSE</PackageLicenseFile>
-    <PackageReadmeFile>README.md</PackageReadmeFile>
-    <RepositoryUrl>https://github.com/Stillpoint-Software/Hyperbee.Pipeline</RepositoryUrl>
-    <RepositoryType>git</RepositoryType>
   </PropertyGroup>
 
   <ItemGroup>
-    <None Include="..\..\assets\icon.png" Pack="true" Visible="false" PackagePath="/" />
-    <None Include="..\..\LICENSE">
-      <Pack>True</Pack>
-      <PackagePath>\</PackagePath>
-    </None>
     <None Include="README.md">
       <Pack>True</Pack>
       <PackagePath>\</PackagePath>

--- a/src/Hyperbee.Pipeline.Validation.FluentValidation/README.md
+++ b/src/Hyperbee.Pipeline.Validation.FluentValidation/README.md
@@ -42,14 +42,16 @@ public class CreateOrderValidator : AbstractValidator<CreateOrderInput>
 
 ```csharp
 using Hyperbee.Pipeline.Validation;
+using Hyperbee.Pipeline.Validation.FluentValidation;
 
-// Recommended: Use helper method
-services.AddFluentValidation(options =>
-    options.ScanAssembly(typeof(CreateOrderValidator).Assembly));
+// Recommended: scan for validators automatically
+services.AddPipelineValidation(config =>
+    config.UseFluentValidation(options =>
+        options.ScanAssembly(typeof(CreateOrderValidator).Assembly)));
 
-// Alternative: Manual registration
-services.AddSingleton<IValidatorProvider, FluentValidatorProvider>();
+// Alternative: if you already register FV validators separately
 services.AddValidatorsFromAssemblyContaining<CreateOrderValidator>();
+services.AddPipelineValidation(config => config.UseFluentValidation());
 ```
 
 ### 3. Use in Pipelines
@@ -171,12 +173,13 @@ services.AddValidatorsFromAssemblyContaining<OrderValidator>();
 <PackageReference Include="Hyperbee.Pipeline.Validation.FluentValidation" />
 
 // Recommended
-services.AddFluentValidation(options =>
-    options.ScanAssembly(typeof(OrderValidator).Assembly));
+services.AddPipelineValidation(config =>
+    config.UseFluentValidation(options =>
+        options.ScanAssembly(typeof(OrderValidator).Assembly)));
 
 // Or keep manual registration
-services.AddSingleton<IValidatorProvider, FluentValidatorProvider>();
 services.AddValidatorsFromAssemblyContaining<OrderValidator>();
+services.AddPipelineValidation(config => config.UseFluentValidation());
 ```
 
 **Pipeline code remains unchanged** - all `ValidateAsync()` calls work exactly the same.
@@ -201,7 +204,9 @@ public class PaymentValidator : IValidator<Payment>
 }
 
 // FluentValidatorProvider handles both via the adapter pattern
-services.AddFluentValidation(options => options.ScanAssembly(Assembly.GetExecutingAssembly()));
+services.AddPipelineValidation(config =>
+    config.UseFluentValidation(options =>
+        options.ScanAssembly(Assembly.GetExecutingAssembly())));
 ```
 
 ## Related Packages

--- a/src/Hyperbee.Pipeline.Validation/Extensions/IPipelineValidationConfiguration.cs
+++ b/src/Hyperbee.Pipeline.Validation/Extensions/IPipelineValidationConfiguration.cs
@@ -1,4 +1,4 @@
-using Microsoft.Extensions.DependencyInjection;
+﻿using Microsoft.Extensions.DependencyInjection;
 
 namespace Hyperbee.Pipeline.Validation;
 

--- a/src/Hyperbee.Pipeline.Validation/Extensions/IPipelineValidationConfiguration.cs
+++ b/src/Hyperbee.Pipeline.Validation/Extensions/IPipelineValidationConfiguration.cs
@@ -1,0 +1,18 @@
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Hyperbee.Pipeline.Validation;
+
+/// <summary>
+/// Provides configuration for pipeline validation, allowing validation providers to be registered
+/// via <c>UseXxx</c> extension methods.
+/// </summary>
+public interface IPipelineValidationConfiguration
+{
+    /// <summary>Gets the underlying service collection.</summary>
+    IServiceCollection Services { get; }
+}
+
+internal sealed class PipelineValidationConfiguration( IServiceCollection services ) : IPipelineValidationConfiguration
+{
+    public IServiceCollection Services { get; } = services;
+}

--- a/src/Hyperbee.Pipeline.Validation/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Hyperbee.Pipeline.Validation/Extensions/ServiceCollectionExtensions.cs
@@ -1,4 +1,4 @@
-using Microsoft.Extensions.DependencyInjection;
+﻿using Microsoft.Extensions.DependencyInjection;
 
 namespace Hyperbee.Pipeline.Validation;
 

--- a/src/Hyperbee.Pipeline.Validation/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Hyperbee.Pipeline.Validation/Extensions/ServiceCollectionExtensions.cs
@@ -1,0 +1,34 @@
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Hyperbee.Pipeline.Validation;
+
+/// <summary>
+/// Provides extension methods for registering pipeline validation with the dependency injection container.
+/// </summary>
+public static class ServiceCollectionExtensions
+{
+    /// <summary>
+    /// Adds pipeline validation infrastructure to the service collection.
+    /// </summary>
+    /// <param name="services">The service collection.</param>
+    /// <param name="configure">
+    /// A configuration delegate for registering validation providers via <c>UseXxx</c> extension methods
+    /// (e.g., <c>config.UseFluentValidation(...)</c>).
+    /// </param>
+    /// <returns>The service collection for method chaining.</returns>
+    /// <example>
+    /// <code>
+    /// services.AddPipelineValidation(config =>
+    ///     config.UseFluentValidation(options =>
+    ///         options.ScanAssembly(typeof(OrderValidator).Assembly)));
+    /// </code>
+    /// </example>
+    public static IServiceCollection AddPipelineValidation(
+        this IServiceCollection services,
+        Action<IPipelineValidationConfiguration>? configure = null )
+    {
+        var config = new PipelineValidationConfiguration( services );
+        configure?.Invoke( config );
+        return services;
+    }
+}

--- a/src/Hyperbee.Pipeline.Validation/Hyperbee.Pipeline.Validation.csproj
+++ b/src/Hyperbee.Pipeline.Validation/Hyperbee.Pipeline.Validation.csproj
@@ -9,21 +9,9 @@
     <PackageId>Hyperbee.Pipeline.Validation</PackageId>
     <Description>Base validation implementations and extensions for Hyperbee.Pipeline async pipelines</Description>
     <PackageTags>pipeline;validation</PackageTags>
-    <PackageIcon>icon.png</PackageIcon>
-    <PackageProjectUrl>https://github.com/Stillpoint-Software/Hyperbee.Pipeline/</PackageProjectUrl>
-    <PackageReleaseNotes>https://github.com/Stillpoint-Software/hyperbee.pipeline/releases/latest</PackageReleaseNotes>
-    <PackageLicenseFile>LICENSE</PackageLicenseFile>
-    <PackageReadmeFile>README.md</PackageReadmeFile>
-    <RepositoryUrl>https://github.com/Stillpoint-Software/Hyperbee.Pipeline</RepositoryUrl>
-    <RepositoryType>git</RepositoryType>
   </PropertyGroup>
 
   <ItemGroup>
-    <None Include="..\..\assets\icon.png" Pack="true" Visible="false" PackagePath="/" />
-    <None Include="..\..\LICENSE">
-      <Pack>True</Pack>
-      <PackagePath>\</PackagePath>
-    </None>
     <None Include="README.md">
       <Pack>True</Pack>
       <PackagePath>\</PackagePath>

--- a/src/Hyperbee.Pipeline/Hyperbee.Pipeline.csproj
+++ b/src/Hyperbee.Pipeline/Hyperbee.Pipeline.csproj
@@ -2,28 +2,18 @@
   <PropertyGroup>
     <IsPackable>true</IsPackable>
     <Authors>Stillpoint Software, Inc.</Authors>
-    <PackageReadmeFile>README.md</PackageReadmeFile>
-    <PackageTags>pipeline;fluent-pipeline;middleware;hooks;dependency-injection</PackageTags>
-    <PackageIcon>icon.png</PackageIcon>
-    <PackageProjectUrl>https://stillpoint-software.github.io/hyperbee.pipeline/</PackageProjectUrl>
-    <PackageReleaseNotes>https://github.com/Stillpoint-Software/hyperbee.pipeline/releases/latest</PackageReleaseNotes>
-    <PackageLicenseFile>LICENSE</PackageLicenseFile>
-    <PackageId>Hyperbee.Pipeline</PackageId>
     <Copyright>Stillpoint Software, Inc.</Copyright>
+    <PackageTags>pipeline;fluent-pipeline;middleware;hooks;dependency-injection</PackageTags>
+    <PackageProjectUrl>https://stillpoint-software.github.io/hyperbee.pipeline/</PackageProjectUrl>
+    <PackageId>Hyperbee.Pipeline</PackageId>
     <Title>Hyperbee Piplines</Title>
     <Description>A pipeline library for constructing asynchronous functional fluent pipelines in .NET</Description>
-    <RepositoryUrl>https://github.com/Stillpoint-Software/Hyperbee.Pipeline</RepositoryUrl>
-    <RepositoryType>git</RepositoryType>
-    <PackageReleaseNotes>https://github.com/Stillpoint-Software/hyperbee.pipeline/releases/latest</PackageReleaseNotes>
-
   </PropertyGroup>
   <ItemGroup>
     <None Update="$(MSBuildProjectName).csproj.DotSettings" Visible="false" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="..\..\assets\icon.png" Pack="true" Visible="false" PackagePath="/" />
     <None Include="..\..\README.md" Pack="true" Visible="true" PackagePath="/" Link="README.md" />
-    <None Include="..\..\LICENSE" Pack="true" Visible="false" PackagePath="/" />
     <PackageReference Update="Microsoft.SourceLink.GitHub" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.Logging" />

--- a/src/Hyperbee.Pipline.Caching/Hyperbee.Pipeline.Caching.csproj
+++ b/src/Hyperbee.Pipline.Caching/Hyperbee.Pipeline.Caching.csproj
@@ -1,20 +1,13 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <IsPackable>true</IsPackable>
     <Authors>Stillpoint Software, Inc.</Authors>
-    <PackageReadmeFile>README.md</PackageReadmeFile>
-    <PackageTags>pipeline;caching</PackageTags>
-    <PackageIcon>icon.png</PackageIcon>
-    <PackageProjectUrl>https://github.com/Stillpoint-Software/Hyperbee.Pipeline/</PackageProjectUrl>
-    <PackageReleaseNotes>https://github.com/Stillpoint-Software/hyperbee.pipeline/releases/latest</PackageReleaseNotes>
-    <PackageLicenseFile>LICENSE</PackageLicenseFile>
-    <PackageId>Hyperbee.Pipeline.Caching</PackageId>
     <Copyright>Stillpoint Software, Inc.</Copyright>
+    <PackageTags>pipeline;caching</PackageTags>
+    <PackageId>Hyperbee.Pipeline.Caching</PackageId>
     <Title>Hyperbee Pipeline Caching</Title>
     <Description>Caching for Hyperbee.Pipelines async pipelines</Description>
-    <RepositoryUrl>https://github.com/Stillpoint-Software/Hyperbee.Pipeline</RepositoryUrl>
-    <RepositoryType>git</RepositoryType>
-    <PackageReleaseNotes>https://github.com/Stillpoint-Software/hyperbee.pipeline/releases/latest</PackageReleaseNotes>
   </PropertyGroup>
 
   <ItemGroup>
@@ -22,11 +15,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="..\..\assets\icon.png" Pack="true" Visible="false" PackagePath="/" />
-    <None Include="..\..\LICENSE">
-      <Pack>True</Pack>
-      <PackagePath>\</PackagePath>
-    </None>
     <None Include="README.md">
       <Pack>True</Pack>
       <PackagePath>\</PackagePath>


### PR DESCRIPTION
## Description

* Improve validation registration pattern. 
* Fix LICENSE and README duplicate file warnings on nuget pack.

```
// Before
services.AddFluentValidation(options =>
    options.ScanAssembly(typeof(CreateOrderValidator).Assembly));

// After
services.AddPipelineValidation(config =>
{
    config.UseFluentValidation(options =>
        options.ScanAssembly(typeof(CreateOrderValidator).Assembly))
});
```

## Type of Change

- [ ] Bug fix
- [X] New feature
- [X] Documentation

## Checklist

- [X] I have run the existing tests and they pass
- [X] I have run the existing benchmarks and verified performance has not decreased
- [X] I have added new tests that prove my change is effective or that my feature works
- [X] I have added the necessary documentation (if applicable)
