### PR TITLE
Adds options for FluentValidation assembly scanning

### DIFF
--- a/docs/validation.md
+++ b/docs/validation.md
@@ -62,6 +62,52 @@ var command = PipelineFactory
 var result = await command(context, new Order { ProductName = "Widget", Amount = 10 });
 ```
 
+## Registration
+
+### ScanAssembly Options
+
+`ScanAssembly` accepts optional parameters that control how FluentValidation registers discovered validators:
+
+| Parameter | Type | Default | Description |
+| --------- | ---- | ------- | ----------- |
+| `assembly` | `Assembly` | _(required)_ | The assembly to scan for validators |
+| `lifetime` | `ServiceLifetime` | `Scoped` | The DI lifetime for registered validators |
+| `includeInternalTypes` | `bool` | `false` | Whether to register validators declared as `internal` |
+
+```csharp
+// Default: Scoped lifetime, public types only
+services.AddPipelineValidation(config =>
+    config.UseFluentValidation(options =>
+        options.ScanAssembly(typeof(OrderValidator).Assembly)));
+
+// Singleton lifetime (e.g. validators with no per-request state)
+services.AddPipelineValidation(config =>
+    config.UseFluentValidation(options =>
+        options.ScanAssembly(typeof(OrderValidator).Assembly, ServiceLifetime.Singleton)));
+
+// Include internal validators
+services.AddPipelineValidation(config =>
+    config.UseFluentValidation(options =>
+        options.ScanAssembly(typeof(OrderValidator).Assembly, includeInternalTypes: true)));
+
+// Scan multiple assemblies with different settings
+services.AddPipelineValidation(config =>
+    config.UseFluentValidation(options =>
+    {
+        options.ScanAssembly(typeof(OrderValidator).Assembly, ServiceLifetime.Singleton);
+        options.ScanAssembly(typeof(PaymentValidator).Assembly);
+    }));
+```
+
+### Pre-registered Validators
+
+If you register FluentValidation validators separately (e.g. with `AddValidatorsFromAssemblyContaining`), omit the scanner:
+
+```csharp
+services.AddValidatorsFromAssemblyContaining<OrderValidator>();
+services.AddPipelineValidation(config => config.UseFluentValidation());
+```
+
 ## Validation Methods
 
 ### Builder Extensions (Declarative)

--- a/src/Hyperbee.Pipeline.Validation.FluentValidation/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Hyperbee.Pipeline.Validation.FluentValidation/Extensions/ServiceCollectionExtensions.cs
@@ -1,4 +1,4 @@
-using System.Reflection;
+﻿using System.Reflection;
 using FluentValidation;
 using Hyperbee.Pipeline.Validation;
 using Microsoft.Extensions.DependencyInjection;

--- a/src/Hyperbee.Pipeline.Validation.FluentValidation/README.md
+++ b/src/Hyperbee.Pipeline.Validation.FluentValidation/README.md
@@ -44,10 +44,20 @@ public class CreateOrderValidator : AbstractValidator<CreateOrderInput>
 using Hyperbee.Pipeline.Validation;
 using Hyperbee.Pipeline.Validation.FluentValidation;
 
-// Recommended: scan for validators automatically
+// Recommended: scan for validators automatically (Scoped lifetime by default)
 services.AddPipelineValidation(config =>
     config.UseFluentValidation(options =>
         options.ScanAssembly(typeof(CreateOrderValidator).Assembly)));
+
+// Singleton lifetime (validators with no per-request state)
+services.AddPipelineValidation(config =>
+    config.UseFluentValidation(options =>
+        options.ScanAssembly(typeof(CreateOrderValidator).Assembly, ServiceLifetime.Singleton)));
+
+// Include internal validator types
+services.AddPipelineValidation(config =>
+    config.UseFluentValidation(options =>
+        options.ScanAssembly(typeof(CreateOrderValidator).Assembly, includeInternalTypes: true)));
 
 // Alternative: if you already register FV validators separately
 services.AddValidatorsFromAssemblyContaining<CreateOrderValidator>();

--- a/test/Hyperbee.Pipeline.Validation.FluentValidation.Tests/ValidatorProviderTests.cs
+++ b/test/Hyperbee.Pipeline.Validation.FluentValidation.Tests/ValidatorProviderTests.cs
@@ -80,6 +80,34 @@ public class ValidatorProviderTests
     }
 
     [TestMethod]
+    public void ScanAssembly_with_default_lifetime_should_register_validators_as_scoped()
+    {
+        var services = new ServiceCollection();
+        services.AddPipelineValidation( config =>
+            config.UseFluentValidation( options =>
+                options.ScanAssembly( typeof( TestOutputValidator ).Assembly ) ) );
+
+        var descriptor = services.FirstOrDefault( d => d.ServiceType == typeof( FV.IValidator<TestOutput> ) );
+
+        Assert.IsNotNull( descriptor );
+        Assert.AreEqual( ServiceLifetime.Scoped, descriptor.Lifetime );
+    }
+
+    [TestMethod]
+    public void ScanAssembly_with_singleton_lifetime_should_register_validators_as_singleton()
+    {
+        var services = new ServiceCollection();
+        services.AddPipelineValidation( config =>
+            config.UseFluentValidation( options =>
+                options.ScanAssembly( typeof( TestOutputValidator ).Assembly, ServiceLifetime.Singleton ) ) );
+
+        var descriptor = services.FirstOrDefault( d => d.ServiceType == typeof( FV.IValidator<TestOutput> ) );
+
+        Assert.IsNotNull( descriptor );
+        Assert.AreEqual( ServiceLifetime.Singleton, descriptor.Lifetime );
+    }
+
+    [TestMethod]
     public void AddPipelineValidation_UseFluentValidation_with_preregistered_validators_should_resolve()
     {
         var services = new ServiceCollection();


### PR DESCRIPTION
## Description

Extends `ScanAssembly` in `FluentValidationOptions` to expose the full registration options
supported by FluentValidation's `AddValidatorsFromAssembly`.

Previously, `ScanAssembly` only accepted an `Assembly` and always registered validators
with the default `Scoped` lifetime. Callers had no way to configure this without
bypassing `ScanAssembly` and calling `AddValidatorsFromAssembly` directly.

**New signature:**
```csharp
options.ScanAssembly(
    assembly,
    lifetime: ServiceLifetime.Singleton,  // default: Scoped
    includeInternalTypes: true);          // default: false
```