### PR TITLE
Add context throwiferror

### DIFF
--- a/src/Hyperbee.Pipeline/Context/IPipelineContext.cs
+++ b/src/Hyperbee.Pipeline/Context/IPipelineContext.cs
@@ -21,6 +21,7 @@ public interface IPipelineContext
 
     void CancelAfter();
     void CancelAfter( object cancellationValue );
+    void ThrowIfError();
     IPipelineContext Clone( bool throws );
 
     string Name { get; set; }

--- a/src/Hyperbee.Pipeline/Context/PipelineContext.cs
+++ b/src/Hyperbee.Pipeline/Context/PipelineContext.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Extensions.Logging;
+﻿using System.Runtime.ExceptionServices;
+using Microsoft.Extensions.Logging;
 
 namespace Hyperbee.Pipeline.Context;
 
@@ -102,6 +103,12 @@ public class PipelineContext : IPipelineContext, IPipelineContextControl
     {
         CancellationSource.Cancel();
         CancellationValue = cancellationValue;
+    }
+
+    public void ThrowIfError()
+    {
+        if ( Exception != null )
+            ExceptionDispatchInfo.Capture( Exception ).Throw();
     }
 
     public IPipelineContext Clone( bool throws = false )

--- a/test/Hyperbee.Pipeline.Tests/PipelineContextThrowIfErrorTests.cs
+++ b/test/Hyperbee.Pipeline.Tests/PipelineContextThrowIfErrorTests.cs
@@ -1,4 +1,4 @@
-using Hyperbee.Pipeline.Context;
+﻿using Hyperbee.Pipeline.Context;
 
 namespace Hyperbee.Pipeline.Tests;
 

--- a/test/Hyperbee.Pipeline.Tests/PipelineContextThrowIfErrorTests.cs
+++ b/test/Hyperbee.Pipeline.Tests/PipelineContextThrowIfErrorTests.cs
@@ -1,0 +1,56 @@
+using Hyperbee.Pipeline.Context;
+
+namespace Hyperbee.Pipeline.Tests;
+
+[TestClass]
+public class PipelineContextThrowIfErrorTests
+{
+    [TestMethod]
+    public void ThrowIfError_should_not_throw_when_no_exception()
+    {
+        var context = new PipelineContext();
+
+        context.ThrowIfError(); // should not throw
+    }
+
+    [TestMethod]
+    public void ThrowIfError_should_throw_when_exception_is_set()
+    {
+        var context = new PipelineContext
+        {
+            Exception = new InvalidOperationException( "test error" )
+        };
+
+        Assert.ThrowsExactly<InvalidOperationException>( () => context.ThrowIfError() );
+    }
+
+    [TestMethod]
+    public void ThrowIfError_should_preserve_original_stack_trace()
+    {
+        var context = new PipelineContext();
+
+        try
+        {
+            ThrowFromNestedMethod();
+        }
+        catch ( Exception ex )
+        {
+            context.Exception = ex;
+        }
+
+        try
+        {
+            context.ThrowIfError();
+            Assert.Fail( "Expected exception was not thrown." );
+        }
+        catch ( InvalidOperationException ex )
+        {
+            Assert.Contains( nameof( ThrowFromNestedMethod ), ex.StackTrace! );
+        }
+    }
+
+    private static void ThrowFromNestedMethod()
+    {
+        throw new InvalidOperationException( "original error" );
+    }
+}

--- a/test/Hyperbee.Pipeline.Tests/PipelineContextThrowIfErrorTests.cs
+++ b/test/Hyperbee.Pipeline.Tests/PipelineContextThrowIfErrorTests.cs
@@ -8,25 +8,30 @@ public class PipelineContextThrowIfErrorTests
     [TestMethod]
     public void ThrowIfError_should_not_throw_when_no_exception()
     {
+        // Arrange
         var context = new PipelineContext();
 
+        // Act & Assert
         context.ThrowIfError(); // should not throw
     }
 
     [TestMethod]
     public void ThrowIfError_should_throw_when_exception_is_set()
     {
+        // Arrange
         var context = new PipelineContext
         {
             Exception = new InvalidOperationException( "test error" )
         };
 
+        // Act & Assert
         Assert.ThrowsExactly<InvalidOperationException>( () => context.ThrowIfError() );
     }
 
     [TestMethod]
     public void ThrowIfError_should_preserve_original_stack_trace()
     {
+        // Arrange
         var context = new PipelineContext();
 
         try
@@ -38,6 +43,7 @@ public class PipelineContextThrowIfErrorTests
             context.Exception = ex;
         }
 
+        // Act
         try
         {
             context.ThrowIfError();
@@ -45,6 +51,7 @@ public class PipelineContextThrowIfErrorTests
         }
         catch ( InvalidOperationException ex )
         {
+            // Assert
             Assert.Contains( nameof( ThrowFromNestedMethod ), ex.StackTrace! );
         }
     }


### PR DESCRIPTION
## Description

Add `ThrowIfError()` method to `IPipelineContext` and `PipelineContext` that uses `ExceptionDispatchInfo.Capture().Throw()` to rethrow captured exceptions while preserving the original stack trace. This provides a safe, discoverable alternative to `throw context.Exception` which would reset the stack trace.

### Motivation
When the pipeline catches an exception (with `Throws = false`), it stores it on `context.Exception`. Consumers who later want to rethrow that exception need to use `ExceptionDispatchInfo` to preserve the original stack trace - a detail that's easy to get wrong. `ThrowIfError()` encapsulates this correctly and follows .NET conventions.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation

## Checklist

- [x] I have run the existing tests and they pass
- [x] I have run the existing benchmarks and verified performance has not decreased
- [x] I have added new tests that prove my change is effective or that my feature works
- [x] I have added the necessary documentation (if applicable)
