### PR TITLE
Inject pipeline middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ as data processing, message handling, and workflow automation.
 Some key features are:
 
 * Middleware
-* Hooks
-* Wraps
+* Hooks and Wraps
+* Middleware providers for cross-cutting concerns
 * Conditional flows
 * Loops
 * Parallel processing
@@ -83,6 +83,24 @@ services.AddPipeline( (factoryServices, rootProvider) =>
     factoryServices.ProxyService<IPrincipalProvider>( rootProvider ); // pull from root container
 } );
 ```
+
+## Middleware Providers
+
+Use `IPipelineMiddlewareProvider` to define cross-cutting middleware (logging, error mapping, etc.) in
+one place and inject it via DI. The `PipelineFactory.Create` convenience method applies hooks and wraps
+automatically:
+
+```csharp
+var command = PipelineFactory.Create<string, string>( middlewareProvider, builder =>
+    builder
+        .Pipe( ( ctx, arg ) => $"hello {arg}" )
+        .Pipe( ( ctx, arg ) => $"{arg}!" )
+);
+```
+
+For explicit control, use `UseHooks` and `UseWraps` builder extensions. See the
+[Middleware documentation](https://stillpoint-software.github.io/hyperbee.pipeline/middleware.html)
+for details.
 
 ## Pipeline of Pipelines
 

--- a/docs/command-pattern.md
+++ b/docs/command-pattern.md
@@ -129,6 +129,49 @@ void usage( IMyCommand command )
 }
 ```
 
+## Example 4
+
+Example of a command using `PipelineFactory.Create` with an injected `IPipelineMiddlewareProvider`
+to automatically apply cross-cutting hooks and wraps.
+
+```csharp
+public interface IDeleteSubscriptionCommand : ICommandFunction<string, DeleteOutput>
+{
+}
+
+public class DeleteSubscriptionCommand : CommandFunction<string, DeleteOutput>, IDeleteSubscriptionCommand
+{
+    private readonly IPipelineMiddlewareProvider _middlewareProvider;
+
+    public DeleteSubscriptionCommand(
+        IPipelineMiddlewareProvider middlewareProvider,
+        IPipelineContextFactory pipelineContextFactory,
+        ILogger<DeleteSubscriptionCommand> logger )
+        : base( pipelineContextFactory, logger )
+    {
+        _middlewareProvider = middlewareProvider;
+    }
+
+    protected override FunctionAsync<string, DeleteOutput> CreatePipeline()
+    {
+        return PipelineFactory.Create<string, DeleteOutput>( _middlewareProvider, builder =>
+            builder
+                .Pipe( ValidateId )
+                .PipeAsync( LoadSubscriptionAsync )
+                .ValidateAsync()
+                .PipeAsync( DeleteSubscriptionAsync )
+                .Pipe( Result )
+        );
+    }
+
+    // ... step methods
+}
+```
+
+The `Create` method applies the provider's hooks after `Start` and wraps before `Build`, so every
+command that uses the provider gets consistent middleware without any extra boilerplate. See
+[Middleware](middleware.md) for more details on `IPipelineMiddlewareProvider`.
+
 ## Composing Commands into Pipelines
 
 Commands expose their inner pipeline delegate via the `PipelineFunction` property. This allows one command's

--- a/docs/dependency-injection.md
+++ b/docs/dependency-injection.md
@@ -60,9 +60,28 @@ PipelineContextFactory.CreateFactory( serviceProvider );
 var factory = PipelineContextFactory.Instance;
 ```
 
-Once you have registered pipeline services, custom middleware can get service instances at runtime 
+Once you have registered pipeline services, custom middleware can get service instances at runtime
 by accessing the `context.ServiceProvider` property.
 
 ```csharp
 context.ServiceProvider.GetRequiredService<IPrincipleProvider>()
+```
+
+## Middleware Provider
+
+Register an `IPipelineMiddlewareProvider` to inject cross-cutting hooks and wraps into pipelines
+via DI. Commands that accept the provider can use `PipelineFactory.Create` to apply the middleware
+automatically. See [Middleware](middleware.md) for details.
+
+```csharp
+services.AddSingleton<IPipelineMiddlewareProvider, MyMiddlewareProvider>();
+```
+
+## Result Mapper
+
+Register an `IResultMapper` to apply shared exception-to-HTTP-status mapping across endpoints.
+See the [AspNetCore README](../src/Hyperbee.Pipeline.AspNetCore/README.md) for details.
+
+```csharp
+services.AddSingleton<IResultMapper, ConflictResultMapper>();
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,8 +24,8 @@ as data processing, message handling, and workflow automation.
 Some key features are:
 
 - Middleware
-- Hooks
-- Wraps
+- Hooks and Wraps
+- Middleware providers for cross-cutting concerns
 - Conditional flows
 - Loops
 - Parallel processing
@@ -97,6 +97,23 @@ services.AddPipeline( (factoryServices, rootProvider) =>
     factoryServices.ProxyService<IPrincipalProvider>( rootProvider ); // pull from root container
 } );
 ```
+
+## Middleware Providers
+
+Use `IPipelineMiddlewareProvider` to define cross-cutting middleware (logging, error mapping, etc.) in
+one place and inject it via DI. The `PipelineFactory.Create` convenience method applies hooks and wraps
+automatically:
+
+```csharp
+var command = PipelineFactory.Create<string, string>( middlewareProvider, builder =>
+    builder
+        .Pipe( ( ctx, arg ) => $"hello {arg}" )
+        .Pipe( ( ctx, arg ) => $"{arg}!" )
+);
+```
+
+For explicit control, use `UseHooks` and `UseWraps` builder extensions. See [Middleware](middleware.md)
+for details.
 
 ## Pipeline of Pipelines
 

--- a/docs/middleware.md
+++ b/docs/middleware.md
@@ -243,3 +243,85 @@ _output:_
 ```
 
 :warning: In this case because the child pipeline does not inherit the parent middleware only the one "jim" hook wraps the `$"hello {++arg}"` step.
+
+## Middleware Provider
+
+When you have cross-cutting middleware concerns (logging, error mapping, etc.) that need to be applied
+consistently across many pipelines, you can use `IPipelineMiddlewareProvider` to define them in one place
+and inject them via DI.
+
+### Defining a Provider
+
+Implement the `IPipelineMiddlewareProvider` interface to supply hooks and wraps:
+
+```csharp
+public class MyMiddlewareProvider : IPipelineMiddlewareProvider
+{
+    private readonly ILogger _logger;
+
+    public MyMiddlewareProvider( ILogger<MyMiddlewareProvider> logger )
+    {
+        _logger = logger;
+    }
+
+    public IEnumerable<MiddlewareAsync<object, object>> Hooks =>
+    [
+        async ( context, argument, next ) =>
+        {
+            _logger.LogDebug( "Step {Id} begin with {Arg}", context.Id, argument );
+            var result = await next( context, argument );
+            _logger.LogDebug( "Step {Id} end with {Result}", context.Id, result );
+            return result;
+        }
+    ];
+
+    public IEnumerable<MiddlewareAsync<object, object>> Wraps =>
+    [
+        async ( context, argument, next ) =>
+        {
+            using var scope = _logger.BeginScope( "Pipeline" );
+            return await next( context, argument );
+        }
+    ];
+}
+```
+
+Register the provider with DI:
+
+```csharp
+services.AddSingleton<IPipelineMiddlewareProvider, MyMiddlewareProvider>();
+```
+
+### Using UseHooks and UseWraps
+
+For explicit control, use the `UseHooks` and `UseWraps` extension methods to apply the provider's
+middleware at specific points in the pipeline:
+
+```csharp
+var command = PipelineFactory
+    .Start<string>()
+    .UseHooks( provider )                    // apply hooks from the provider
+    .Pipe( ( ctx, arg ) => $"hello {arg}" )
+    .Pipe( ( ctx, arg ) => $"{arg}!" )
+    .UseWraps( provider )                    // apply wraps from the provider
+    .Build();
+```
+
+### Using PipelineFactory.Create
+
+For the common case, use the `PipelineFactory.Create` convenience method. It applies hooks after
+`Start` and wraps before `Build` automatically:
+
+```csharp
+var command = PipelineFactory.Create<string, string>( provider, builder =>
+    builder
+        .Pipe( ( ctx, arg ) => $"hello {arg}" )
+        .Pipe( ( ctx, arg ) => $"{arg}!" )
+);
+```
+
+This is equivalent to calling `Start`, `UseHooks`, your pipeline steps, `UseWraps`, and `Build`
+manually. The `Create` method is especially useful when many commands share the same provider,
+as it reduces boilerplate and ensures consistent middleware application.
+
+See [Commands](command-pattern.md) for an example of using `Create` inside a command class.

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -325,7 +325,7 @@ Available failure types:
 When using `Hyperbee.Pipeline.AspNetCore`, validation failures are automatically mapped to HTTP responses:
 
 ```csharp
-using Hyperbee.Pipeline.AspNetCore;
+using Hyperbee.Pipeline.AspNetCore.Extensions;
 
 app.MapPost("/orders", async (Order order, ICommandFunction<Order, OrderResult> command) =>
 {
@@ -336,9 +336,44 @@ app.MapPost("/orders", async (Order order, ICommandFunction<Order, OrderResult> 
     // - 404 Not Found for NotFoundValidationFailure
     // - 401 Unauthorized for UnauthorizedValidationFailure
     // - 403 Forbidden for ForbiddenValidationFailure
-    return result.ToHttpResult();
+    return result.ToResult();
 });
 ```
+
+### Custom Result Mapping
+
+Use a `resultMapper` to handle specific exceptions alongside validation failures:
+
+```csharp
+app.MapPost("/orders", async (Order order, ICommandFunction<Order, OrderResult> command) =>
+{
+    var result = await command.ExecuteAsync(order);
+    return result.ToResult( cr =>
+    {
+        if ( cr.Context.IsError && cr.Context.Exception is DbUpdateConcurrencyException )
+            return Results.Conflict( "Version conflict. Reload and retry." );
+        return null; // fall through to default validation/error handling
+    } );
+});
+```
+
+For shared mapping logic across many endpoints, implement `IResultMapper` and register it with DI:
+
+```csharp
+services.AddSingleton<IResultMapper, ConflictResultMapper>();
+
+app.MapPost("/orders", async (
+    Order order,
+    ICommandFunction<Order, OrderResult> command,
+    IResultMapper resultMapper) =>
+{
+    var result = await command.ExecuteAsync(order);
+    return result.ToResult( resultMapper );
+});
+```
+
+See the [AspNetCore README](../src/Hyperbee.Pipeline.AspNetCore/README.md) for full details on
+`IResultMapper` and all `ToResult` overloads.
 
 ## Advanced Scenarios
 

--- a/src/Hyperbee.Pipeline.AspNetCore/Extensions/CommandResultExtensions.cs
+++ b/src/Hyperbee.Pipeline.AspNetCore/Extensions/CommandResultExtensions.cs
@@ -1,4 +1,4 @@
-﻿using System.Reflection;
+using System.Reflection;
 using Hyperbee.Pipeline.Commands;
 using Hyperbee.Pipeline.Context;
 using Hyperbee.Pipeline.Validation;
@@ -27,6 +27,63 @@ public static class CommandResultExtensions
     /// result; otherwise, returns an <see cref="IResult"/> with the successful result.</returns>
     public static IResult ToResult<T>( this CommandResult<T> commandResult )
     {
+        if ( TryHandleInvalidCommand( commandResult.Context, commandResult.CommandType, out var errorResult ) )
+            return errorResult;
+
+        return Results.Ok( commandResult.Result );
+    }
+
+    /// <summary>
+    /// Converts a <see cref="CommandResult{T}"/> to an <see cref="IResult"/> using a result mapper
+    /// that has full access to the command result for custom error and success handling.
+    /// </summary>
+    /// <remarks>
+    /// The <paramref name="resultMapper"/> runs before default error handling. If it returns a non-null
+    /// <see cref="IResult"/>, that result is used directly. If it returns <see langword="null"/>, the
+    /// default error and success handling logic applies.
+    /// </remarks>
+    /// <typeparam name="T">The type of the result contained in the <see cref="CommandResult{T}"/>.</typeparam>
+    /// <param name="commandResult">The command result to convert.</param>
+    /// <param name="resultMapper">A function that inspects the full command result and optionally returns
+    /// an <see cref="IResult"/>. Return <see langword="null"/> to fall through to default handling.</param>
+    /// <returns>An <see cref="IResult"/> representing the outcome of the command.</returns>
+    public static IResult ToResult<T>(
+        this CommandResult<T> commandResult,
+        Func<CommandResult<T>, IResult?> resultMapper
+    )
+    {
+        var mapped = resultMapper( commandResult );
+        if ( mapped != null )
+            return mapped;
+
+        if ( TryHandleInvalidCommand( commandResult.Context, commandResult.CommandType, out var errorResult ) )
+            return errorResult;
+
+        return Results.Ok( commandResult.Result );
+    }
+
+    /// <summary>
+    /// Converts a <see cref="CommandResult{T}"/> to an <see cref="IResult"/> using an injected
+    /// <see cref="IResultMapper"/> for cross-cutting result handling.
+    /// </summary>
+    /// <remarks>
+    /// The mapper runs before default error handling. If it returns a non-null
+    /// <see cref="IResult"/>, that result is used directly. If it returns <see langword="null"/>, the
+    /// default error and success handling logic applies.
+    /// </remarks>
+    /// <typeparam name="T">The type of the result contained in the <see cref="CommandResult{T}"/>.</typeparam>
+    /// <param name="commandResult">The command result to convert.</param>
+    /// <param name="resultMapper">An <see cref="IResultMapper"/> that inspects the command result.</param>
+    /// <returns>An <see cref="IResult"/> representing the outcome of the command.</returns>
+    public static IResult ToResult<T>(
+        this CommandResult<T> commandResult,
+        IResultMapper resultMapper
+    )
+    {
+        var mapped = resultMapper.Map( commandResult );
+        if ( mapped != null )
+            return mapped;
+
         if ( TryHandleInvalidCommand( commandResult.Context, commandResult.CommandType, out var errorResult ) )
             return errorResult;
 
@@ -73,6 +130,61 @@ public static class CommandResultExtensions
     /// result; otherwise, returns a successful result.</returns>
     public static IResult ToResult( this CommandResult commandResult )
     {
+        if ( TryHandleInvalidCommand( commandResult.Context, commandResult.CommandType, out var errorResult ) )
+            return errorResult;
+
+        return Results.Ok();
+    }
+
+    /// <summary>
+    /// Converts a <see cref="CommandResult"/> to an <see cref="IResult"/> using a result mapper
+    /// that has full access to the command result for custom error and success handling.
+    /// </summary>
+    /// <remarks>
+    /// The <paramref name="resultMapper"/> runs before default error handling. If it returns a non-null
+    /// <see cref="IResult"/>, that result is used directly. If it returns <see langword="null"/>, the
+    /// default error and success handling logic applies.
+    /// </remarks>
+    /// <param name="commandResult">The command result to convert.</param>
+    /// <param name="resultMapper">A function that inspects the full command result and optionally returns
+    /// an <see cref="IResult"/>. Return <see langword="null"/> to fall through to default handling.</param>
+    /// <returns>An <see cref="IResult"/> representing the outcome of the command.</returns>
+    public static IResult ToResult(
+        this CommandResult commandResult,
+        Func<CommandResult, IResult?> resultMapper
+    )
+    {
+        var mapped = resultMapper( commandResult );
+        if ( mapped != null )
+            return mapped;
+
+        if ( TryHandleInvalidCommand( commandResult.Context, commandResult.CommandType, out var errorResult ) )
+            return errorResult;
+
+        return Results.Ok();
+    }
+
+    /// <summary>
+    /// Converts a <see cref="CommandResult"/> to an <see cref="IResult"/> using an injected
+    /// <see cref="IResultMapper"/> for cross-cutting result handling.
+    /// </summary>
+    /// <remarks>
+    /// The mapper runs before default error handling. If it returns a non-null
+    /// <see cref="IResult"/>, that result is used directly. If it returns <see langword="null"/>, the
+    /// default error and success handling logic applies.
+    /// </remarks>
+    /// <param name="commandResult">The command result to convert.</param>
+    /// <param name="resultMapper">An <see cref="IResultMapper"/> that inspects the command result.</param>
+    /// <returns>An <see cref="IResult"/> representing the outcome of the command.</returns>
+    public static IResult ToResult(
+        this CommandResult commandResult,
+        IResultMapper resultMapper
+    )
+    {
+        var mapped = resultMapper.Map( commandResult );
+        if ( mapped != null )
+            return mapped;
+
         if ( TryHandleInvalidCommand( commandResult.Context, commandResult.CommandType, out var errorResult ) )
             return errorResult;
 

--- a/src/Hyperbee.Pipeline.AspNetCore/Extensions/CommandResultExtensions.cs
+++ b/src/Hyperbee.Pipeline.AspNetCore/Extensions/CommandResultExtensions.cs
@@ -1,4 +1,4 @@
-using System.Reflection;
+﻿using System.Reflection;
 using Hyperbee.Pipeline.Commands;
 using Hyperbee.Pipeline.Context;
 using Hyperbee.Pipeline.Validation;

--- a/src/Hyperbee.Pipeline.AspNetCore/IResultMapper.cs
+++ b/src/Hyperbee.Pipeline.AspNetCore/IResultMapper.cs
@@ -1,0 +1,30 @@
+using Hyperbee.Pipeline.Commands;
+using Microsoft.AspNetCore.Http;
+
+namespace Hyperbee.Pipeline.AspNetCore;
+
+/// <summary>
+/// Maps a <see cref="CommandResult"/> to an <see cref="IResult"/> for cross-cutting error handling.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Register implementations in the DI container and inject into endpoints to apply shared
+/// result mapping logic (e.g., converting specific exceptions to HTTP status codes).
+/// </para>
+/// <para>
+/// The mapper runs before default error handling. Return an <see cref="IResult"/> to handle the
+/// command result, or <see langword="null"/> to fall through to the default handling logic.
+/// </para>
+/// </remarks>
+public interface IResultMapper
+{
+    /// <summary>
+    /// Attempts to map the given command result to an <see cref="IResult"/>.
+    /// </summary>
+    /// <param name="commandResult">The command result to inspect.</param>
+    /// <returns>
+    /// An <see cref="IResult"/> if this mapper handles the command result;
+    /// otherwise, <see langword="null"/> to delegate to default handling.
+    /// </returns>
+    IResult? Map( CommandResult commandResult );
+}

--- a/src/Hyperbee.Pipeline.AspNetCore/IResultMapper.cs
+++ b/src/Hyperbee.Pipeline.AspNetCore/IResultMapper.cs
@@ -1,4 +1,4 @@
-using Hyperbee.Pipeline.Commands;
+﻿using Hyperbee.Pipeline.Commands;
 using Microsoft.AspNetCore.Http;
 
 namespace Hyperbee.Pipeline.AspNetCore;

--- a/src/Hyperbee.Pipeline.AspNetCore/README.md
+++ b/src/Hyperbee.Pipeline.AspNetCore/README.md
@@ -41,6 +41,63 @@ app.MapGet( "/reports/{id}", async (
 } );
 ```
 
+### Custom Result Mapping
+
+Use a `resultMapper` to handle specific exceptions or customize both error and success responses.
+The mapper receives the full `CommandResult` and returns an `IResult`, or `null` to fall through
+to default handling.
+
+```csharp
+app.MapPost( "/items", async (
+    CreateItemRequest request,
+    ICommandFunction<CreateItemRequest, Item> command ) =>
+{
+    var commandResult = await command.ExecuteAsync( request );
+    return commandResult.ToResult( cr =>
+    {
+        if ( cr.Context.IsError && cr.Context.Exception is DbUpdateConcurrencyException )
+            return Results.Conflict( "Version conflict. Reload and retry." );
+        return null; // fall through to default handling
+    } );
+} );
+```
+
+### Cross-Cutting Result Mapping with IResultMapper
+
+For shared result mapping logic, implement the `IResultMapper` interface and register it with DI.
+This is useful when multiple endpoints need the same exception-to-HTTP-status mapping.
+
+```csharp
+public class ConflictResultMapper : IResultMapper
+{
+    public IResult? Map( CommandResult commandResult )
+    {
+        if ( commandResult.Context.IsError &&
+             commandResult.Context.Exception is DbUpdateConcurrencyException )
+        {
+            return Results.Conflict( "Version conflict. Reload and retry." );
+        }
+
+        return null; // fall through to default handling
+    }
+}
+```
+
+Register with DI and inject into endpoints:
+
+```csharp
+services.AddSingleton<IResultMapper, ConflictResultMapper>();
+
+app.MapPost( "/items", async (
+    CreateItemRequest request,
+    ICommandFunction<CreateItemRequest, Item> command,
+    IResultMapper resultMapper ) =>
+{
+    var commandResult = await command.ExecuteAsync( request );
+    return commandResult.ToResult( resultMapper );
+} );
+```
+
 ### Automatic Error Mapping
 
 Validation failures are automatically converted to appropriate HTTP status codes with

--- a/src/Hyperbee.Pipeline.TestHelpers/PipelineContextFactoryFixture.cs
+++ b/src/Hyperbee.Pipeline.TestHelpers/PipelineContextFactoryFixture.cs
@@ -15,6 +15,13 @@ public class PipelineContextFactoryFixture
 {
     private static readonly AsyncLocal<ContextState> _asyncLocalState = new();
 
+    /// <summary>
+    /// Gets or sets a default <see cref="IPipelineMiddlewareProvider"/> that is automatically
+    /// registered with every fixture instance. Set this once in test setup (e.g., [AssemblyInitialize])
+    /// to apply shared middleware across all tests.
+    /// </summary>
+    public static IPipelineMiddlewareProvider? DefaultMiddlewareProvider { get; set; }
+
     private readonly string _contextId;
 
     public PipelineContextFactoryFixture()
@@ -57,6 +64,31 @@ public class PipelineContextFactoryFixture
     }
 
     /// <summary>
+    /// Registers an <see cref="IPipelineMiddlewareProvider"/> for injection into commands.
+    /// </summary>
+    /// <typeparam name="TProvider">The middleware provider type to register.</typeparam>
+    public PipelineContextFactoryFixture WithMiddlewareProvider<TProvider>()
+        where TProvider : class, IPipelineMiddlewareProvider, new()
+    {
+        var state = GetState();
+        state.Services.AddSingleton<IPipelineMiddlewareProvider>( new TProvider() );
+        state.HasMiddlewareProvider = true;
+        return this;
+    }
+
+    /// <summary>
+    /// Registers an <see cref="IPipelineMiddlewareProvider"/> instance for injection into commands.
+    /// </summary>
+    /// <param name="provider">The middleware provider instance to register.</param>
+    public PipelineContextFactoryFixture WithMiddlewareProvider( IPipelineMiddlewareProvider provider )
+    {
+        var state = GetState();
+        state.Services.AddSingleton( provider );
+        state.HasMiddlewareProvider = true;
+        return this;
+    }
+
+    /// <summary>
     /// Configures the service collection for DI setup.
     /// </summary>
     public PipelineContextFactoryFixture WithServices( Action<IServiceCollection> configure )
@@ -73,6 +105,10 @@ public class PipelineContextFactoryFixture
     public IPipelineContextFactory Create()
     {
         var state = GetState();
+
+        // Register the default middleware provider if set and not explicitly overridden
+        if ( DefaultMiddlewareProvider is { } defaultProvider && !state.HasMiddlewareProvider )
+            state.Services.AddSingleton<IPipelineMiddlewareProvider>( defaultProvider );
 
         // Register the validator provider as a singleton
         state.Services.AddSingleton<IValidatorProvider>( state.ValidatorProvider );
@@ -150,5 +186,6 @@ public class PipelineContextFactoryFixture
         public ServiceCollection Services { get; init; } = null!;
         public TestValidatorProvider ValidatorProvider { get; init; } = null!;
         public IServiceProvider? ServiceProvider { get; set; }
+        public bool HasMiddlewareProvider { get; set; }
     }
 }

--- a/src/Hyperbee.Pipeline.TestHelpers/README.md
+++ b/src/Hyperbee.Pipeline.TestHelpers/README.md
@@ -37,6 +37,26 @@ public async Task Should_return_result_when_input_is_valid()
 }
 ```
 
+### Register a Middleware Provider
+
+```csharp
+// Set a default provider for all tests (e.g., in [AssemblyInitialize])
+PipelineContextFactoryFixture.DefaultMiddlewareProvider = new LoggingMiddlewareProvider();
+
+// Every fixture automatically includes it
+var factory = PipelineContextFactoryFixture.Default();
+
+// Or register per-fixture (overrides the default)
+var factory = new PipelineContextFactoryFixture()
+    .WithMiddlewareProvider<LoggingMiddlewareProvider>()
+    .Create();
+
+// Or with an instance
+var factory = new PipelineContextFactoryFixture()
+    .WithMiddlewareProvider( new LoggingMiddlewareProvider( logger ) )
+    .Create();
+```
+
 ### Register Custom Services
 
 ```csharp

--- a/src/Hyperbee.Pipeline/Builders/MiddlewareProviderBuilder.cs
+++ b/src/Hyperbee.Pipeline/Builders/MiddlewareProviderBuilder.cs
@@ -1,4 +1,4 @@
-namespace Hyperbee.Pipeline;
+﻿namespace Hyperbee.Pipeline;
 
 /// <summary>
 /// Provides extension methods for applying middleware from an <see cref="IPipelineMiddlewareProvider"/>

--- a/src/Hyperbee.Pipeline/Builders/MiddlewareProviderBuilder.cs
+++ b/src/Hyperbee.Pipeline/Builders/MiddlewareProviderBuilder.cs
@@ -1,0 +1,63 @@
+namespace Hyperbee.Pipeline;
+
+/// <summary>
+/// Provides extension methods for applying middleware from an <see cref="IPipelineMiddlewareProvider"/>
+/// to a pipeline builder.
+/// </summary>
+public static class MiddlewareProviderBuilder
+{
+    /// <summary>
+    /// Applies hook middleware from the provider at the start of the pipeline.
+    /// </summary>
+    /// <typeparam name="TStart">The input type of the pipeline.</typeparam>
+    /// <typeparam name="TOutput">The output type of the pipeline.</typeparam>
+    /// <param name="builder">The pipeline start builder.</param>
+    /// <param name="provider">The middleware provider supplying hooks.</param>
+    /// <returns>The pipeline start builder with hooks applied.</returns>
+    public static IPipelineStartBuilder<TStart, TOutput> UseHooks<TStart, TOutput>(
+        this IPipelineStartBuilder<TStart, TOutput> builder,
+        IPipelineMiddlewareProvider provider
+    )
+    {
+        if ( provider == null )
+            return builder;
+
+        return builder.HookAsync( provider.Hooks );
+    }
+
+    /// <summary>
+    /// Applies wrap middleware from the provider around the pipeline.
+    /// </summary>
+    /// <typeparam name="TStart">The input type of the pipeline.</typeparam>
+    /// <typeparam name="TOutput">The output type of the pipeline.</typeparam>
+    /// <param name="builder">The pipeline builder.</param>
+    /// <param name="provider">The middleware provider supplying wraps.</param>
+    /// <returns>The pipeline builder with wraps applied.</returns>
+    public static IPipelineBuilder<TStart, TOutput> UseWraps<TStart, TOutput>(
+        this IPipelineBuilder<TStart, TOutput> builder,
+        IPipelineMiddlewareProvider provider
+    )
+    {
+        if ( provider == null )
+            return builder;
+
+        foreach ( var wrap in provider.Wraps )
+        {
+            var capturedWrap = wrap;
+            builder = builder.WrapAsync(
+                async ( context, argument, next ) =>
+                {
+                    var result = await capturedWrap(
+                        context,
+                        argument!,
+                        async ( ctx, arg ) => (object) await next( ctx, (TStart) arg )!
+                    ).ConfigureAwait( false );
+
+                    return (TOutput) result;
+                }
+            );
+        }
+
+        return builder;
+    }
+}

--- a/src/Hyperbee.Pipeline/Builders/MiddlewareProviderBuilder.cs
+++ b/src/Hyperbee.Pipeline/Builders/MiddlewareProviderBuilder.cs
@@ -19,7 +19,7 @@ public static class MiddlewareProviderBuilder
         IPipelineMiddlewareProvider provider
     )
     {
-        if ( provider == null )
+        if ( provider == null || provider.Hooks == null || !provider.Hooks.Any() )
             return builder;
 
         return builder.HookAsync( provider.Hooks );
@@ -38,7 +38,7 @@ public static class MiddlewareProviderBuilder
         IPipelineMiddlewareProvider provider
     )
     {
-        if ( provider == null )
+        if ( provider == null || provider.Wraps == null || !provider.Wraps.Any() )
             return builder;
 
         foreach ( var wrap in provider.Wraps )

--- a/src/Hyperbee.Pipeline/IPipelineMiddlewareProvider.cs
+++ b/src/Hyperbee.Pipeline/IPipelineMiddlewareProvider.cs
@@ -1,0 +1,32 @@
+namespace Hyperbee.Pipeline;
+
+/// <summary>
+/// Provides hooks and wraps that can be injected into pipeline definitions.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This interface enables cross-cutting middleware concerns (logging, error mapping, etc.)
+/// to be composed into pipelines without modifying individual command definitions.
+/// </para>
+/// <para>
+/// Hooks are function middleware applied at the start of the pipeline, wrapping every step.
+/// Wraps are pipeline middleware applied around the entire pipeline.
+/// </para>
+/// <para>
+/// Register implementations in the DI container and inject into commands that need shared middleware.
+/// Use <c>UseHooks</c> and <c>UseWraps</c> builder extensions for explicit control, or use
+/// <c>PipelineFactory.Create</c> for a convenience wrapper that applies both automatically.
+/// </para>
+/// </remarks>
+public interface IPipelineMiddlewareProvider
+{
+    /// <summary>
+    /// Gets the hook middleware to apply at the start of the pipeline.
+    /// </summary>
+    IEnumerable<MiddlewareAsync<object, object>> Hooks { get; }
+
+    /// <summary>
+    /// Gets the wrap middleware to apply around the pipeline.
+    /// </summary>
+    IEnumerable<MiddlewareAsync<object, object>> Wraps { get; }
+}

--- a/src/Hyperbee.Pipeline/IPipelineMiddlewareProvider.cs
+++ b/src/Hyperbee.Pipeline/IPipelineMiddlewareProvider.cs
@@ -1,4 +1,4 @@
-namespace Hyperbee.Pipeline;
+﻿namespace Hyperbee.Pipeline;
 
 /// <summary>
 /// Provides hooks and wraps that can be injected into pipeline definitions.

--- a/src/Hyperbee.Pipeline/PipelineFactory.cs
+++ b/src/Hyperbee.Pipeline/PipelineFactory.cs
@@ -56,4 +56,28 @@ public class PipelineFactory
             Middleware = functionMiddleware
         };
     }
+
+    /// <summary>
+    /// Creates a pipeline with middleware from a provider applied automatically.
+    /// Hooks are applied after Start, wraps are applied before Build.
+    /// </summary>
+    /// <typeparam name="TStart">The input type of the pipeline.</typeparam>
+    /// <typeparam name="TOutput">The output type of the pipeline.</typeparam>
+    /// <param name="provider">The middleware provider supplying hooks and wraps.</param>
+    /// <param name="configure">A function that configures the pipeline steps.</param>
+    /// <returns>The built pipeline function.</returns>
+    public static FunctionAsync<TStart, TOutput> Create<TStart, TOutput>(
+        IPipelineMiddlewareProvider provider,
+        Func<IPipelineStartBuilder<TStart, TStart>, IPipelineBuilder<TStart, TOutput>> configure
+    )
+    {
+        ArgumentNullException.ThrowIfNull( configure );
+
+        var builder = Start<TStart>()
+            .UseHooks( provider );
+
+        return configure( builder )
+            .UseWraps( provider )
+            .Build();
+    }
 }

--- a/src/Hyperbee.Pipeline/PipelineFactory.cs
+++ b/src/Hyperbee.Pipeline/PipelineFactory.cs
@@ -32,6 +32,11 @@
 //
 public class PipelineFactory
 {
+    /// <summary>
+    /// Starts a pipeline with an identity function. This is the monadic 'return' or 'pure' operation, which lifts a value into the pipeline context.
+    /// </summary>
+    /// <typeparam name="TStart"></typeparam>
+    /// <returns></returns>
     public static IPipelineStartBuilder<TStart, TStart> Start<TStart>()
     {
         return new PipelineBuilder<TStart, TStart>
@@ -40,6 +45,10 @@ public class PipelineFactory
         };
     }
 
+    /// <summary>
+    /// Starts a pipeline with an identity function and an initial middleware. This overload allows you to provide middleware that will be applied at the start of the pipeline, before any steps are configured. The provided middleware will wrap the initial identity function, allowing you to inject behavior right from the beginning of the pipeline execution.
+    /// </summary>
+    /// <returns></returns>
     public static IPipelineStartBuilder<Arg.Empty, Arg.Empty> Start()
     {
         return new PipelineBuilder<Arg.Empty, Arg.Empty>
@@ -58,6 +67,23 @@ public class PipelineFactory
     }
 
     /// <summary>
+    /// Creates a pipeline by applying a configuration function.
+    /// </summary>
+    /// <typeparam name="TStart">The input type of the pipeline.</typeparam>
+    /// <typeparam name="TOutput">The output type of the pipeline.</typeparam>
+    /// <param name="configure">A function that configures the pipeline steps.</param>
+    /// <returns>The built pipeline function.</returns>
+    public static FunctionAsync<TStart, TOutput> Create<TStart, TOutput>(
+        Func<IPipelineStartBuilder<TStart, TStart>, IPipelineBuilder<TStart, TOutput>> configure
+    )
+    {
+        ArgumentNullException.ThrowIfNull( configure );
+
+        return configure( Start<TStart>() )
+            .Build();
+    }
+
+    /// <summary>
     /// Creates a pipeline with middleware from a provider applied automatically.
     /// Hooks are applied after Start, wraps are applied before Build.
     /// </summary>
@@ -71,6 +97,7 @@ public class PipelineFactory
         Func<IPipelineStartBuilder<TStart, TStart>, IPipelineBuilder<TStart, TOutput>> configure
     )
     {
+        ArgumentNullException.ThrowIfNull( provider );
         ArgumentNullException.ThrowIfNull( configure );
 
         var builder = Start<TStart>()

--- a/test/Hyperbee.Pipeline.AspNetCore.Tests/ResultMapperTests.cs
+++ b/test/Hyperbee.Pipeline.AspNetCore.Tests/ResultMapperTests.cs
@@ -1,4 +1,4 @@
-using Hyperbee.Pipeline.AspNetCore.Extensions;
+﻿using Hyperbee.Pipeline.AspNetCore.Extensions;
 using Hyperbee.Pipeline.Commands;
 using Hyperbee.Pipeline.Context;
 using Microsoft.AspNetCore.Http;

--- a/test/Hyperbee.Pipeline.AspNetCore.Tests/ResultMapperTests.cs
+++ b/test/Hyperbee.Pipeline.AspNetCore.Tests/ResultMapperTests.cs
@@ -1,0 +1,254 @@
+using Hyperbee.Pipeline.AspNetCore.Extensions;
+using Hyperbee.Pipeline.Commands;
+using Hyperbee.Pipeline.Context;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.HttpResults;
+
+namespace Hyperbee.Pipeline.AspNetCore.Tests;
+
+[TestClass]
+public class ResultMapperTests
+{
+    private static CommandResult<T> CreateErrorResult<T>( Exception exception )
+    {
+        var context = new PipelineContext { Exception = exception };
+        return new CommandResult<T>
+        {
+            Context = context,
+            CommandType = typeof( ResultMapperTests )
+        };
+    }
+
+    private static CommandResult CreateNonGenericErrorResult( Exception exception )
+    {
+        var context = new PipelineContext { Exception = exception };
+        return new CommandResult
+        {
+            Context = context,
+            CommandType = typeof( ResultMapperTests )
+        };
+    }
+
+    private static CommandResult<T> CreateSuccessResult<T>( T value )
+    {
+        var context = new PipelineContext();
+        return new CommandResult<T>
+        {
+            Context = context,
+            Result = value,
+            CommandType = typeof( ResultMapperTests )
+        };
+    }
+
+    // Generic ToResult with resultMapper
+
+    [TestMethod]
+    public void ToResult_with_resultMapper_should_return_mapped_result_on_error()
+    {
+        var commandResult = CreateErrorResult<string>(
+            new InvalidOperationException( "version conflict detected" )
+        );
+
+        var result = commandResult.ToResult( cr =>
+        {
+            if ( cr.Context.IsError && cr.Context.Exception is InvalidOperationException ex &&
+                 ex.Message.Contains( "version conflict" ) )
+                return Results.Conflict( "Version conflict. Reload and retry." );
+            return null;
+        } );
+
+        Assert.IsInstanceOfType( result, typeof( Conflict<string> ) );
+    }
+
+    [TestMethod]
+    public void ToResult_with_resultMapper_should_fall_through_to_default_on_success()
+    {
+        var commandResult = CreateSuccessResult( "hello" );
+
+        var result = commandResult.ToResult( cr => null );
+
+        Assert.IsInstanceOfType( result, typeof( Ok<string> ) );
+    }
+
+    [TestMethod]
+    public void ToResult_with_resultMapper_should_allow_success_override()
+    {
+        var commandResult = CreateSuccessResult( "hello" );
+
+        var result = commandResult.ToResult( cr =>
+        {
+            if ( cr.Context.Success )
+                return Results.NoContent();
+            return null;
+        } );
+
+        Assert.IsInstanceOfType( result, typeof( NoContent ) );
+    }
+
+    [TestMethod]
+    public void ToResult_with_resultMapper_should_handle_combined_error_and_success()
+    {
+        var successResult = CreateSuccessResult( "hello" );
+        var errorResult = CreateErrorResult<string>(
+            new InvalidOperationException( "version conflict" )
+        );
+
+        IResult? Mapper( CommandResult<string> cr )
+        {
+            if ( cr.Context.IsError && cr.Context.Exception is InvalidOperationException )
+                return Results.Conflict( "Version conflict." );
+            if ( cr.Context.Success )
+                return Results.NoContent();
+            return null;
+        }
+
+        var successIResult = successResult.ToResult( Mapper );
+        var errorIResult = errorResult.ToResult( Mapper );
+
+        Assert.IsInstanceOfType( successIResult, typeof( NoContent ) );
+        Assert.IsInstanceOfType( errorIResult, typeof( Conflict<string> ) );
+    }
+
+    [TestMethod]
+    public void ToResult_with_resultMapper_should_fall_through_to_default_error_handling()
+    {
+        var commandResult = CreateErrorResult<string>(
+            new InvalidOperationException( "some other error" )
+        );
+
+        // Mapper doesn't handle this error type — returns null, so default handling throws
+        try
+        {
+            commandResult.ToResult( cr =>
+            {
+                if ( cr.Context.Exception is ArgumentException )
+                    return Results.Conflict( "Handled." );
+                return null;
+            } );
+            Assert.Fail( "Expected CommandException to be thrown." );
+        }
+        catch ( CommandException )
+        {
+            // Expected
+        }
+    }
+
+    // Non-generic ToResult with resultMapper
+
+    [TestMethod]
+    public void ToResult_non_generic_with_resultMapper_should_return_mapped_result()
+    {
+        var commandResult = CreateNonGenericErrorResult(
+            new InvalidOperationException( "version conflict" )
+        );
+
+        var result = commandResult.ToResult( cr =>
+        {
+            if ( cr.Context.IsError && cr.Context.Exception is InvalidOperationException )
+                return Results.Conflict( "Version conflict." );
+            return null;
+        } );
+
+        Assert.IsInstanceOfType( result, typeof( Conflict<string> ) );
+    }
+
+    [TestMethod]
+    public void ToResult_non_generic_with_resultMapper_should_fall_through_on_success()
+    {
+        var commandResult = new CommandResult
+        {
+            Context = new PipelineContext(),
+            CommandType = typeof( ResultMapperTests )
+        };
+
+        var result = commandResult.ToResult( cr => null );
+
+        Assert.IsInstanceOfType( result, typeof( Ok ) );
+    }
+
+    // IResultMapper interface tests
+
+    private class ConflictResultMapper : IResultMapper
+    {
+        public IResult? Map( CommandResult commandResult )
+        {
+            if ( commandResult.Context.IsError &&
+                 commandResult.Context.Exception is InvalidOperationException ex &&
+                 ex.Message.Contains( "version conflict" ) )
+            {
+                return Results.Conflict( "Version conflict. Reload and retry." );
+            }
+
+            return null;
+        }
+    }
+
+    [TestMethod]
+    public void ToResult_with_IResultMapper_should_return_mapped_result_on_error()
+    {
+        var commandResult = CreateErrorResult<string>(
+            new InvalidOperationException( "version conflict detected" )
+        );
+        var mapper = new ConflictResultMapper();
+
+        var result = commandResult.ToResult( mapper );
+
+        Assert.IsInstanceOfType( result, typeof( Conflict<string> ) );
+    }
+
+    [TestMethod]
+    public void ToResult_with_IResultMapper_should_fall_through_to_default_on_success()
+    {
+        var commandResult = CreateSuccessResult( "hello" );
+        var mapper = new ConflictResultMapper();
+
+        var result = commandResult.ToResult( mapper );
+
+        Assert.IsInstanceOfType( result, typeof( Ok<string> ) );
+    }
+
+    [TestMethod]
+    public void ToResult_with_IResultMapper_should_fall_through_on_unhandled_error()
+    {
+        var commandResult = CreateErrorResult<string>( new ArgumentException( "bad arg" ) );
+        var mapper = new ConflictResultMapper();
+
+        try
+        {
+            commandResult.ToResult( mapper );
+            Assert.Fail( "Expected CommandException to be thrown." );
+        }
+        catch ( CommandException )
+        {
+            // Expected — mapper returned null, default handling throws
+        }
+    }
+
+    [TestMethod]
+    public void ToResult_non_generic_with_IResultMapper_should_return_mapped_result()
+    {
+        var commandResult = CreateNonGenericErrorResult(
+            new InvalidOperationException( "version conflict detected" )
+        );
+        var mapper = new ConflictResultMapper();
+
+        var result = commandResult.ToResult( mapper );
+
+        Assert.IsInstanceOfType( result, typeof( Conflict<string> ) );
+    }
+
+    [TestMethod]
+    public void ToResult_non_generic_with_IResultMapper_should_fall_through_on_success()
+    {
+        var commandResult = new CommandResult
+        {
+            Context = new PipelineContext(),
+            CommandType = typeof( ResultMapperTests )
+        };
+        var mapper = new ConflictResultMapper();
+
+        var result = commandResult.ToResult( mapper );
+
+        Assert.IsInstanceOfType( result, typeof( Ok ) );
+    }
+}

--- a/test/Hyperbee.Pipeline.Tests/PipelineMiddlewareProviderTests.cs
+++ b/test/Hyperbee.Pipeline.Tests/PipelineMiddlewareProviderTests.cs
@@ -1,4 +1,4 @@
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using Hyperbee.Pipeline.Context;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 

--- a/test/Hyperbee.Pipeline.Tests/PipelineMiddlewareProviderTests.cs
+++ b/test/Hyperbee.Pipeline.Tests/PipelineMiddlewareProviderTests.cs
@@ -1,0 +1,268 @@
+using System.Threading.Tasks;
+using Hyperbee.Pipeline.Context;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Hyperbee.Pipeline.Tests;
+
+[TestClass]
+public class PipelineMiddlewareProviderTests
+{
+    private class TestMiddlewareProvider : IPipelineMiddlewareProvider
+    {
+        private readonly List<MiddlewareAsync<object, object>> _hooks = [];
+        private readonly List<MiddlewareAsync<object, object>> _wraps = [];
+
+        public TestMiddlewareProvider AddHook( MiddlewareAsync<object, object> hook )
+        {
+            _hooks.Add( hook );
+            return this;
+        }
+
+        public TestMiddlewareProvider AddWrap( MiddlewareAsync<object, object> wrap )
+        {
+            _wraps.Add( wrap );
+            return this;
+        }
+
+        public IEnumerable<MiddlewareAsync<object, object>> Hooks => _hooks;
+        public IEnumerable<MiddlewareAsync<object, object>> Wraps => _wraps;
+    }
+
+    // UseHooks / UseWraps tests
+
+    [TestMethod]
+    public async Task UseHooks_should_apply_hooks_from_provider()
+    {
+        var provider = new TestMiddlewareProvider()
+            .AddHook( async ( ctx, arg, next ) => await next( ctx, arg + "{" ) + "}" );
+
+        var command = PipelineFactory
+            .Start<string>()
+            .UseHooks( provider )
+            .Pipe( ( ctx, arg ) => arg + "1" )
+            .Build();
+
+        var result = await command( new PipelineContext() );
+
+        Assert.AreEqual( "{1}", result );
+    }
+
+    [TestMethod]
+    public async Task UseHooks_should_apply_multiple_hooks_from_provider()
+    {
+        var provider = new TestMiddlewareProvider()
+            .AddHook( async ( ctx, arg, next ) => await next( ctx, arg + "{" ) + "}" )
+            .AddHook( async ( ctx, arg, next ) => await next( ctx, arg + "[" ) + "]" );
+
+        var command = PipelineFactory
+            .Start<string>()
+            .UseHooks( provider )
+            .Pipe( ( ctx, arg ) => arg + "1" )
+            .Build();
+
+        var result = await command( new PipelineContext() );
+
+        // Each hook wraps independently per the HookAsync(IEnumerable) implementation
+        Assert.AreEqual( "[1]", result );
+    }
+
+    [TestMethod]
+    public async Task UseWraps_should_apply_wraps_from_provider()
+    {
+        var provider = new TestMiddlewareProvider()
+            .AddWrap( async ( ctx, arg, next ) => await next( ctx, arg + "{" ) + "}" );
+
+        var command = PipelineFactory
+            .Start<string>()
+            .Pipe( ( ctx, arg ) => arg + "1" )
+            .Pipe( ( ctx, arg ) => arg + "2" )
+            .UseWraps( provider )
+            .Pipe( ( ctx, arg ) => arg + "3" )
+            .Build();
+
+        var result = await command( new PipelineContext() );
+
+        Assert.AreEqual( "{12}3", result );
+    }
+
+    [TestMethod]
+    public async Task UseHooks_and_UseWraps_should_work_together()
+    {
+        var provider = new TestMiddlewareProvider()
+            .AddHook( async ( ctx, arg, next ) => await next( ctx, arg + "(" ) + ")" )
+            .AddWrap( async ( ctx, arg, next ) => await next( ctx, arg + "[" ) + "]" );
+
+        var command = PipelineFactory
+            .Start<string>()
+            .UseHooks( provider )
+            .Pipe( ( ctx, arg ) => arg + "1" )
+            .Pipe( ( ctx, arg ) => arg + "2" )
+            .UseWraps( provider )
+            .Build();
+
+        var result = await command( new PipelineContext() );
+
+        Assert.AreEqual( "[(1)(2)]", result );
+    }
+
+    [TestMethod]
+    public async Task UseHooks_with_null_provider_should_be_no_op()
+    {
+        var command = PipelineFactory
+            .Start<string>()
+            .UseHooks( null )
+            .Pipe( ( ctx, arg ) => arg + "1" )
+            .Build();
+
+        var result = await command( new PipelineContext() );
+
+        Assert.AreEqual( "1", result );
+    }
+
+    [TestMethod]
+    public async Task UseWraps_with_null_provider_should_be_no_op()
+    {
+        var command = PipelineFactory
+            .Start<string>()
+            .Pipe( ( ctx, arg ) => arg + "1" )
+            .UseWraps( null )
+            .Build();
+
+        var result = await command( new PipelineContext() );
+
+        Assert.AreEqual( "1", result );
+    }
+
+    [TestMethod]
+    public async Task UseHooks_with_empty_provider_should_be_no_op()
+    {
+        var provider = new TestMiddlewareProvider();
+
+        var command = PipelineFactory
+            .Start<string>()
+            .UseHooks( provider )
+            .Pipe( ( ctx, arg ) => arg + "1" )
+            .Build();
+
+        var result = await command( new PipelineContext() );
+
+        Assert.AreEqual( "1", result );
+    }
+
+    [TestMethod]
+    public async Task UseWraps_with_empty_provider_should_be_no_op()
+    {
+        var provider = new TestMiddlewareProvider();
+
+        var command = PipelineFactory
+            .Start<string>()
+            .Pipe( ( ctx, arg ) => arg + "1" )
+            .UseWraps( provider )
+            .Build();
+
+        var result = await command( new PipelineContext() );
+
+        Assert.AreEqual( "1", result );
+    }
+
+    // PipelineFactory.Create tests
+
+    [TestMethod]
+    public async Task Create_should_apply_hooks_and_wraps_from_provider()
+    {
+        var provider = new TestMiddlewareProvider()
+            .AddHook( async ( ctx, arg, next ) => await next( ctx, arg + "(" ) + ")" )
+            .AddWrap( async ( ctx, arg, next ) => await next( ctx, arg + "[" ) + "]" );
+
+        var command = PipelineFactory.Create<string, string>( provider, builder =>
+            builder
+                .Pipe( ( ctx, arg ) => arg + "1" )
+                .Pipe( ( ctx, arg ) => arg + "2" )
+        );
+
+        var result = await command( new PipelineContext() );
+
+        Assert.AreEqual( "[(1)(2)]", result );
+    }
+
+    [TestMethod]
+    public async Task Create_should_work_with_hooks_only()
+    {
+        var provider = new TestMiddlewareProvider()
+            .AddHook( async ( ctx, arg, next ) => await next( ctx, arg + "{" ) + "}" );
+
+        var command = PipelineFactory.Create<string, string>( provider, builder =>
+            builder
+                .Pipe( ( ctx, arg ) => arg + "1" )
+        );
+
+        var result = await command( new PipelineContext() );
+
+        Assert.AreEqual( "{1}", result );
+    }
+
+    [TestMethod]
+    public async Task Create_should_work_with_wraps_only()
+    {
+        var provider = new TestMiddlewareProvider()
+            .AddWrap( async ( ctx, arg, next ) => await next( ctx, arg + "[" ) + "]" );
+
+        var command = PipelineFactory.Create<string, string>( provider, builder =>
+            builder
+                .Pipe( ( ctx, arg ) => arg + "1" )
+                .Pipe( ( ctx, arg ) => arg + "2" )
+        );
+
+        var result = await command( new PipelineContext() );
+
+        Assert.AreEqual( "[12]", result );
+    }
+
+    [TestMethod]
+    public async Task Create_should_work_with_null_provider()
+    {
+        var command = PipelineFactory.Create<string, string>( null, builder =>
+            builder
+                .Pipe( ( ctx, arg ) => arg + "1" )
+        );
+
+        var result = await command( new PipelineContext() );
+
+        Assert.AreEqual( "1", result );
+    }
+
+    [TestMethod]
+    public async Task Create_should_work_with_empty_provider()
+    {
+        var provider = new TestMiddlewareProvider();
+
+        var command = PipelineFactory.Create<string, string>( provider, builder =>
+            builder
+                .Pipe( ( ctx, arg ) => arg + "1" )
+        );
+
+        var result = await command( new PipelineContext() );
+
+        Assert.AreEqual( "1", result );
+    }
+
+    [TestMethod]
+    public async Task Create_should_work_with_async_steps()
+    {
+        var provider = new TestMiddlewareProvider()
+            .AddHook( async ( ctx, arg, next ) => await next( ctx, arg + "(" ) + ")" );
+
+        var command = PipelineFactory.Create<string, string>( provider, builder =>
+            builder
+                .PipeAsync( async ( ctx, arg ) =>
+                {
+                    await Task.Delay( 1 );
+                    return arg + "async";
+                } )
+        );
+
+        var result = await command( new PipelineContext() );
+
+        Assert.AreEqual( "(async)", result );
+    }
+}


### PR DESCRIPTION
# Summary

`IResultMapper` + `resultMapper` overloads: `ToResult` now accepts a `Func<CommandResult<T>, IResult?>` lambda or an `IResultMapper` interface for custom error/success handling. The mapper runs before default error handling - return an `IResult` to handle it, or null to fall through. Solves the problem of needing specialized `ToResult*` methods for custom error mapping.

`IPipelineMiddlewareProvider`: New interface with Hooks and Wraps properties for defining cross-cutting middleware in one place. Register with DI and inject into commands.

`UseHooks` / `UseWraps`: Builder extensions for explicit middleware application from a provider.

`PipelineFactory.Create`: Convenience method that applies hooks after Start and wraps before Build automatically, reducing boilerplate across many pipelines.

`PipelineContextFactoryFixture`: Added `WithMiddlewareProvider` and `DefaultMiddlewareProvider` for test support.

 MiddlewareProvider tests: UseHooks, UseWraps, PipelineFactory.Create, null/empty providers

## Type of Change

- [ ] Bug fix
- [x] New feature
- [x] Documentation

## Checklist

- [x] I have run the existing tests and they pass
- [x] I have run the existing benchmarks and verified performance has not decreased
- [x] I have added new tests that prove my change is effective or that my feature works
- [x] I have added the necessary documentation (if applicable)
