### PR TITLE
Fix WithNoContent to preserve error results instead of silently replacing them

### DIFF
--- a/src/Hyperbee.Pipeline.AspNetCore/Extensions/ResultExtensions.cs
+++ b/src/Hyperbee.Pipeline.AspNetCore/Extensions/ResultExtensions.cs
@@ -24,16 +24,31 @@ public static class ResultExtensions
     }
 
     /// <summary>
-    /// Replaces the response with a 204 No Content result while preserving all
-    /// previously chained decorators (e.g., headers).
+    /// Replaces a successful response with a 204 No Content result while preserving all
+    /// previously chained decorators (e.g., headers). Non-success results (e.g., validation
+    /// errors, exceptions) are returned unchanged.
     /// </summary>
     /// <param name="result">The result to replace.</param>
-    /// <returns>A 204 No Content <see cref="IResult"/> with all prior decorators preserved.</returns>
+    /// <returns>A 204 No Content <see cref="IResult"/> if the original result was successful;
+    /// otherwise, the original result unchanged.</returns>
     public static IResult WithNoContent( this IResult result )
     {
-        if ( result is DecoratedResult decorated )
-            return new DecoratedResult( Results.NoContent(), decorated.Decorators );
+        if ( !IsSuccessResult( result ) )
+            return result;
+
+        if ( result is DecoratedResult dec )
+            return new DecoratedResult( Results.NoContent(), dec.Decorators );
 
         return Results.NoContent();
+    }
+
+    private static bool IsSuccessResult( IResult result )
+    {
+        // Unwrap DecoratedResult to inspect the actual response status code
+        var effective = result is DecoratedResult decorated ? decorated.Inner : result;
+
+        // Only treat confirmed 2xx as success. If the result doesn't expose a
+        // status code, preserve it unchanged — safe default over silent replacement.
+        return effective is IStatusCodeHttpResult { StatusCode: >= 200 and <= 299 };
     }
 }

--- a/test/Hyperbee.Pipeline.AspNetCore.Tests/ResultExtensionsTests.cs
+++ b/test/Hyperbee.Pipeline.AspNetCore.Tests/ResultExtensionsTests.cs
@@ -157,4 +157,125 @@ public class ResultExtensionsTests
 
         Assert.AreEqual( StatusCodes.Status204NoContent, httpContext.Response.StatusCode );
     }
+
+    // WithNoContent error-preservation tests
+
+    [TestMethod]
+    public async Task WithNoContent_should_preserve_422_validation_error()
+    {
+        var result = Results.Problem(
+            detail: "Validation failed.",
+            statusCode: StatusCodes.Status422UnprocessableEntity
+        ).WithNoContent();
+
+        var httpContext = CreateHttpContext();
+        await result.ExecuteAsync( httpContext );
+
+        Assert.AreEqual( StatusCodes.Status422UnprocessableEntity, httpContext.Response.StatusCode );
+    }
+
+    [TestMethod]
+    public async Task WithNoContent_should_preserve_401_unauthorized()
+    {
+        var result = Results.Problem(
+            detail: "Unauthorized.",
+            statusCode: StatusCodes.Status401Unauthorized
+        ).WithNoContent();
+
+        var httpContext = CreateHttpContext();
+        await result.ExecuteAsync( httpContext );
+
+        Assert.AreEqual( StatusCodes.Status401Unauthorized, httpContext.Response.StatusCode );
+    }
+
+    [TestMethod]
+    public async Task WithNoContent_should_preserve_403_forbidden()
+    {
+        var result = Results.Problem(
+            detail: "Forbidden.",
+            statusCode: StatusCodes.Status403Forbidden
+        ).WithNoContent();
+
+        var httpContext = CreateHttpContext();
+        await result.ExecuteAsync( httpContext );
+
+        Assert.AreEqual( StatusCodes.Status403Forbidden, httpContext.Response.StatusCode );
+    }
+
+    [TestMethod]
+    public async Task WithNoContent_should_preserve_404_not_found()
+    {
+        var result = Results.NotFound().WithNoContent();
+
+        var httpContext = CreateHttpContext();
+        await result.ExecuteAsync( httpContext );
+
+        Assert.AreEqual( StatusCodes.Status404NotFound, httpContext.Response.StatusCode );
+    }
+
+    [TestMethod]
+    public async Task WithNoContent_should_preserve_500_error()
+    {
+        var result = Results.Problem(
+            detail: "Server error.",
+            statusCode: StatusCodes.Status500InternalServerError
+        ).WithNoContent();
+
+        var httpContext = CreateHttpContext();
+        await result.ExecuteAsync( httpContext );
+
+        Assert.AreEqual( StatusCodes.Status500InternalServerError, httpContext.Response.StatusCode );
+    }
+
+    [TestMethod]
+    public async Task WithNoContent_should_preserve_error_with_headers()
+    {
+        var result = Results.Problem(
+            detail: "Not found.",
+            statusCode: StatusCodes.Status404NotFound
+        )
+        .WithHeader( "X-Trace", "abc" )
+        .WithNoContent();
+
+        var httpContext = CreateHttpContext();
+        await result.ExecuteAsync( httpContext );
+
+        Assert.AreEqual( StatusCodes.Status404NotFound, httpContext.Response.StatusCode );
+        Assert.AreEqual( "abc", httpContext.Response.Headers["X-Trace"].ToString() );
+    }
+
+    // WithNoContent should convert all 2xx success responses
+
+    [TestMethod]
+    public async Task WithNoContent_should_replace_200_ok()
+    {
+        var result = Results.Ok( "hello" ).WithNoContent();
+
+        var httpContext = CreateHttpContext();
+        await result.ExecuteAsync( httpContext );
+
+        Assert.AreEqual( StatusCodes.Status204NoContent, httpContext.Response.StatusCode );
+    }
+
+    [TestMethod]
+    public async Task WithNoContent_should_replace_201_created()
+    {
+        var result = Results.Created( "/items/1", new { Id = 1 } ).WithNoContent();
+
+        var httpContext = CreateHttpContext();
+        await result.ExecuteAsync( httpContext );
+
+        Assert.AreEqual( StatusCodes.Status204NoContent, httpContext.Response.StatusCode );
+    }
+
+    [TestMethod]
+    public async Task WithNoContent_should_replace_202_accepted()
+    {
+        var result = Results.Accepted().WithNoContent();
+
+        var httpContext = CreateHttpContext();
+        await result.ExecuteAsync( httpContext );
+
+        Assert.AreEqual( StatusCodes.Status204NoContent, httpContext.Response.StatusCode );
+    }
 }


### PR DESCRIPTION
## Description

- `WithNoContent()` unconditionally replaced **any** `IResult` with 204 NoContent — including validation errors (422), unauthorized (401), forbidden (403), not found (404), and server errors (500)
- Now only confirmed 2xx results are replaced; errors and unknown status codes pass through unchanged
- Extracted `IsSuccessResult` helper with a **safe default**: if the status code can't be determined, the result is preserved rather than silently replaced

## Root cause
`WithNoContent` was written as a mechanical body-swap without considering that it sits downstream of `ToResult(mapper)`, which can return error results. The original tests only covered the happy path (success → 204).

## What changed

**`ResultExtensions.cs`** — `WithNoContent` now calls `IsSuccessResult` before replacing. The check unwraps `DecoratedResult` and uses a positive match (`IStatusCodeHttpResult { StatusCode: >= 200 and <= 299 }`), so unrecognized results are never silently discarded.

**`ResultExtensionsTests.cs`** — Added 9 new tests covering:
| Scenario | Expected |
|---|---|
| 422 Unprocessable Entity | Preserved |
| 401 Unauthorized | Preserved |
| 403 Forbidden | Preserved |
| 404 Not Found | Preserved |
| 500 Internal Server Error | Preserved |
| Error + chained headers | Both preserved |
| 200 OK | Replaced with 204 |
| 201 Created | Replaced with 204 |
| 202 Accepted | Replaced with 204 |

