### PR TITLE
Add ICommandProcedure test helpers and fix error-context wiring

### DIFF
--- a/Hyperbee.Pipeline.slnx
+++ b/Hyperbee.Pipeline.slnx
@@ -25,6 +25,7 @@
     <Project Path="test/Hyperbee.Pipeline.Validation.Tests/Hyperbee.Pipeline.Validation.Tests.csproj" />
     <Project Path="test/Hyperbee.Pipeline.Validation.FluentValidation.Tests/Hyperbee.Pipeline.Validation.FluentValidation.Tests.csproj" />
     <Project Path="test/Hyperbee.Pipeline.AspNetCore.Tests/Hyperbee.Pipeline.AspNetCore.Tests.csproj" />
+    <Project Path="test/Hyperbee.Pipeline.TestHelpers.Tests/Hyperbee.Pipeline.TestHelpers.Tests.csproj" />
   </Folder>
   <Project Path="src/Hyperbee.Pipeline.Auth/Hyperbee.Pipeline.Auth.csproj" />
   <Project Path="src/Hyperbee.Pipeline/Hyperbee.Pipeline.csproj" />

--- a/src/Hyperbee.Pipeline.TestHelpers/CommandFunctionHelpers.cs
+++ b/src/Hyperbee.Pipeline.TestHelpers/CommandFunctionHelpers.cs
@@ -61,4 +61,35 @@ public static class CommandFunctionHelpers
     {
         commandFunction.MockCommandFunction( () => CommandResultHelpers.CreateWithException<TOutput>( exception ) );
     }
+
+    /// <summary>
+    /// Mocks a command procedure to return a successful result (no output).
+    /// </summary>
+    /// <typeparam name="TStart">The input type for the command procedure.</typeparam>
+    /// <param name="commandProcedure">The command procedure to mock.</param>
+    public static void MockSuccessfulResult<TStart>( this ICommandProcedure<TStart> commandProcedure )
+    {
+        var commandResult = CommandResultHelpers.CreateSuccess();
+
+        commandProcedure.ExecuteAsync(
+            NSubstitute.Arg.Any<TStart>(),
+            NSubstitute.Arg.Any<CancellationToken>() )
+            .Returns( commandResult );
+    }
+
+    /// <summary>
+    /// Mocks a command procedure to return an exception result with the specified exception.
+    /// </summary>
+    /// <typeparam name="TStart">The input type for the command procedure.</typeparam>
+    /// <param name="commandProcedure">The command procedure to mock.</param>
+    /// <param name="exception">The exception to include in the result.</param>
+    public static void MockExceptionCommandResult<TStart>( this ICommandProcedure<TStart> commandProcedure, Exception exception )
+    {
+        var commandResult = CommandResultHelpers.CreateWithException( exception );
+
+        commandProcedure.ExecuteAsync(
+            NSubstitute.Arg.Any<TStart>(),
+            NSubstitute.Arg.Any<CancellationToken>() )
+            .Returns( commandResult );
+    }
 }

--- a/src/Hyperbee.Pipeline.TestHelpers/CommandResultHelpers.cs
+++ b/src/Hyperbee.Pipeline.TestHelpers/CommandResultHelpers.cs
@@ -91,8 +91,7 @@ public static class CommandResultHelpers
     /// <returns>A CommandResult with an exception.</returns>
     public static CommandResult<TOutput> CreateWithException<TOutput>( Exception exception, Type? commandType = null )
     {
-        var context = CreateContext();
-        context.Exception.Returns( exception );
+        var context = CreateErrorContext( exception );
 
         return new CommandResult<TOutput>
         {
@@ -118,6 +117,21 @@ public static class CommandResultHelpers
             nonPublic: true )!;
 
         context.Items.Returns( contextItems );
+
+        return context;
+    }
+
+    /// <summary>
+    /// Creates a mock IPipelineContext in an error state, with ThrowIfError() wired to throw the supplied exception.
+    /// </summary>
+    /// <param name="exception">The exception to associate with the context.</param>
+    /// <returns>A mocked IPipelineContext in an error state.</returns>
+    private static IPipelineContext CreateErrorContext( Exception exception )
+    {
+        var context = CreateContext();
+        context.IsError.Returns( true );
+        context.Exception.Returns( exception );
+        context.When( c => c.ThrowIfError() ).Do( _ => throw exception );
 
         return context;
     }

--- a/src/Hyperbee.Pipeline.TestHelpers/CommandResultHelpers.cs
+++ b/src/Hyperbee.Pipeline.TestHelpers/CommandResultHelpers.cs
@@ -8,6 +8,30 @@ namespace Hyperbee.Pipeline.TestHelpers;
 public static class CommandResultHelpers
 {
     /// <summary>
+    /// Creates a successful CommandResult (no output) for an <see cref="ICommandProcedure{TStart}"/>.
+    /// </summary>
+    /// <returns>A CommandResult with valid state.</returns>
+    public static CommandResult CreateSuccess()
+    {
+        var context = CreateContext();
+        context.SetValidationResult( new ValidationResult() );
+
+        return new CommandResult { Context = context };
+    }
+
+    /// <summary>
+    /// Creates a failed CommandResult (no output) whose ThrowIfError() throws the supplied exception.
+    /// </summary>
+    /// <param name="exception">The exception to set in the context.</param>
+    /// <returns>A CommandResult in an error state.</returns>
+    public static CommandResult CreateWithException( Exception exception )
+    {
+        var context = CreateErrorContext( exception );
+
+        return new CommandResult { Context = context };
+    }
+
+    /// <summary>
     /// Creates a CommandResult with a successful validation result.
     /// </summary>
     /// <typeparam name="TOutput">The output type of the command result.</typeparam>

--- a/src/Hyperbee.Pipeline.TestHelpers/README.md
+++ b/src/Hyperbee.Pipeline.TestHelpers/README.md
@@ -37,6 +37,24 @@ public async Task Should_return_result_when_input_is_valid()
 }
 ```
 
+### Mock a Command Procedure
+
+`ICommandProcedure<TStart>` commands have no output. Mock them the same way as command functions:
+
+```csharp
+var procedure = Substitute.For<ICommandProcedure<OrderInput>>();
+
+// Successful (no-output) result
+procedure.MockSuccessfulResult();
+
+// Or an error result whose ThrowIfError() throws
+procedure.MockExceptionCommandResult( new InvalidOperationException( "failed" ) );
+
+var result = await procedure.ExecuteAsync( new OrderInput { Name = "Widget" } );
+
+Assert.False( result.Context.IsError );
+```
+
 ### Register a Middleware Provider
 
 ```csharp

--- a/test/Hyperbee.Pipeline.TestHelpers.Tests/CommandFunctionHelpersTests.cs
+++ b/test/Hyperbee.Pipeline.TestHelpers.Tests/CommandFunctionHelpersTests.cs
@@ -1,0 +1,37 @@
+using Hyperbee.Pipeline.Commands;
+using Hyperbee.Pipeline.TestHelpers;
+using NSubstitute;
+
+namespace Hyperbee.Pipeline.TestHelpers.Tests;
+
+[TestClass]
+public class CommandFunctionHelpersTests
+{
+    [TestMethod]
+    public async Task MockSuccessfulResult_procedure_returns_success()
+    {
+        var procedure = Substitute.For<ICommandProcedure<string>>();
+
+        procedure.MockSuccessfulResult();
+
+        var result = await procedure.ExecuteAsync( "input" );
+
+        Assert.IsNotNull( result );
+        Assert.IsFalse( result.Context.IsError );
+    }
+
+    [TestMethod]
+    public async Task MockExceptionCommandResult_procedure_returns_error()
+    {
+        var exception = new InvalidOperationException( "boom" );
+        var procedure = Substitute.For<ICommandProcedure<string>>();
+
+        procedure.MockExceptionCommandResult( exception );
+
+        var result = await procedure.ExecuteAsync( "input" );
+
+        Assert.IsTrue( result.Context.IsError );
+        Assert.AreSame( exception, result.Context.Exception );
+        Assert.ThrowsExactly<InvalidOperationException>( () => result.Context.ThrowIfError() );
+    }
+}

--- a/test/Hyperbee.Pipeline.TestHelpers.Tests/CommandFunctionHelpersTests.cs
+++ b/test/Hyperbee.Pipeline.TestHelpers.Tests/CommandFunctionHelpersTests.cs
@@ -1,4 +1,4 @@
-using Hyperbee.Pipeline.Commands;
+﻿using Hyperbee.Pipeline.Commands;
 using Hyperbee.Pipeline.TestHelpers;
 using NSubstitute;
 

--- a/test/Hyperbee.Pipeline.TestHelpers.Tests/CommandResultHelpersTests.cs
+++ b/test/Hyperbee.Pipeline.TestHelpers.Tests/CommandResultHelpersTests.cs
@@ -18,4 +18,26 @@ public class CommandResultHelpersTests
         Assert.AreEqual( typeof( string ), result.CommandType );
         Assert.ThrowsExactly<InvalidOperationException>( () => result.Context.ThrowIfError() );
     }
+
+    [TestMethod]
+    public void CreateSuccess_procedure_is_not_error_and_is_valid()
+    {
+        var result = CommandResultHelpers.CreateSuccess();
+
+        Assert.IsNotNull( result.Context );
+        Assert.IsFalse( result.Context.IsError );
+        Assert.IsTrue( result.Context.GetValidationResult()!.IsValid );
+    }
+
+    [TestMethod]
+    public void CreateWithException_procedure_wires_error_state_and_throws()
+    {
+        var exception = new InvalidOperationException( "boom" );
+
+        var result = CommandResultHelpers.CreateWithException( exception );
+
+        Assert.IsTrue( result.Context.IsError );
+        Assert.AreSame( exception, result.Context.Exception );
+        Assert.ThrowsExactly<InvalidOperationException>( () => result.Context.ThrowIfError() );
+    }
 }

--- a/test/Hyperbee.Pipeline.TestHelpers.Tests/CommandResultHelpersTests.cs
+++ b/test/Hyperbee.Pipeline.TestHelpers.Tests/CommandResultHelpersTests.cs
@@ -1,0 +1,21 @@
+using Hyperbee.Pipeline.TestHelpers;
+using Hyperbee.Pipeline.Validation;
+
+namespace Hyperbee.Pipeline.TestHelpers.Tests;
+
+[TestClass]
+public class CommandResultHelpersTests
+{
+    [TestMethod]
+    public void CreateWithException_generic_wires_error_state_and_throws()
+    {
+        var exception = new InvalidOperationException( "boom" );
+
+        var result = CommandResultHelpers.CreateWithException<string>( exception );
+
+        Assert.IsTrue( result.Context.IsError );
+        Assert.AreSame( exception, result.Context.Exception );
+        Assert.AreEqual( typeof( string ), result.CommandType );
+        Assert.ThrowsExactly<InvalidOperationException>( () => result.Context.ThrowIfError() );
+    }
+}

--- a/test/Hyperbee.Pipeline.TestHelpers.Tests/CommandResultHelpersTests.cs
+++ b/test/Hyperbee.Pipeline.TestHelpers.Tests/CommandResultHelpersTests.cs
@@ -1,4 +1,4 @@
-using Hyperbee.Pipeline.TestHelpers;
+﻿using Hyperbee.Pipeline.TestHelpers;
 using Hyperbee.Pipeline.Validation;
 
 namespace Hyperbee.Pipeline.TestHelpers.Tests;

--- a/test/Hyperbee.Pipeline.TestHelpers.Tests/Hyperbee.Pipeline.TestHelpers.Tests.csproj
+++ b/test/Hyperbee.Pipeline.TestHelpers.Tests/Hyperbee.Pipeline.TestHelpers.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <Nullable>enable</Nullable>

--- a/test/Hyperbee.Pipeline.TestHelpers.Tests/Hyperbee.Pipeline.TestHelpers.Tests.csproj
+++ b/test/Hyperbee.Pipeline.TestHelpers.Tests/Hyperbee.Pipeline.TestHelpers.Tests.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="MSTest.TestAdapter" />
+    <PackageReference Include="MSTest.TestFramework" />
+    <PackageReference Include="NSubstitute" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Hyperbee.Pipeline.TestHelpers\Hyperbee.Pipeline.TestHelpers.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Microsoft.VisualStudio.TestTools.UnitTesting" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Update="Microsoft.SourceLink.GitHub" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
## Description

Adds test-helper support for `ICommandProcedure<TStart>` (procedures have no output), mirroring the existing `ICommandFunction` helpers, and fixes the error-context wiring shared by both.

- `CommandResultHelpers.CreateSuccess()` and `CreateWithException( Exception )` — non-generic factories for procedure results.
- `CommandFunctionHelpers.MockSuccessfulResult<TStart>()` and `MockExceptionCommandResult<TStart>( Exception )` — procedure mock extensions.
- Fixes the existing `CreateWithException<TOutput>` so the context reports `IsError` and `ThrowIfError()` actually throws (previously only `Exception` was set). A new shared `CreateErrorContext` backs both the generic and non-generic exception factories.
- Adds a new `Hyperbee.Pipeline.TestHelpers.Tests` MSTest project covering the new helpers and the corrected error wiring, registered in `Hyperbee.Pipeline.slnx`.

 - Fixes #107

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation

## Checklist

- [x] I have run the existing tests and they pass
- [x] I have run the existing benchmarks and verified performance has not decreased
- [x] I have added new tests that prove my change is effective or that my feature works
- [x] I have added the necessary documentation (if applicable)
